### PR TITLE
Initial bundle setup & feature implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+composer.lock
+phpunit.xml
+vendor/
+php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,21 @@
+<?php
+
+if (!file_exists(__DIR__.'/src')) {
+    exit(0);
+}
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/src')
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules(array(
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'protected_to_private' => false,
+        'semicolon_after_instruction' => false,
+    ))
+    ->setRiskyAllowed(true)
+    ->setFinder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: php
+sudo: false
+cache:
+    directories:
+        - $HOME/.composer/cache/files
+        - $HOME/symfony-bridge/.phpunit
+
+env:
+    global:
+        - PHPUNIT_FLAGS="-v"
+        - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+
+matrix:
+    fast_finish: true
+    include:
+        - php: 7.1
+        - php: 7.1
+          env: deps=high
+        - php: 7.2
+          env: deps=low
+
+    allow_failures:
+          # Dev-master is allowed to fail.
+        - env: STABILITY="dev"
+
+before_install:
+    - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
+    - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
+    - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
+    - composer install
+
+install:
+    - |
+      # Install symfony/flex
+      if [[ $deps = low ]]; then
+          export SYMFONY_REQUIRE='>=2.3'
+      fi
+      composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
+    - ./vendor/bin/simple-phpunit install
+
+script:
+    - composer validate --strict --no-check-lock
+    - ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# WebpackEncoreBundle: Symfony integration with Webpack Encore!
+
+This bundle allows you to use the `splitEntryChunks()` feature
+from [Webpack Encore](https://symfony.com/doc/current/frontend.html)
+by reading an `entrypoints.json` file and helping you render all of
+the dynamic `script` and `link` tags needed.
+
+Install the bundle with:
+
+```
+composer require symfony/webpack-encore-bundle
+```
+
+## Configuration
+
+If you're using Symfony Flex, you're done! The recipe will
+pre-configure everything you need in the `config/packages/webpack_encore.yaml`
+file:
+
+```yaml
+# config/packages/webpack_encore.yaml
+webpack_encore:
+    # The path where Encore is building the assets - i.e. Encore.setOutputPath()
+    output_path: '%kernel.public_dir%/build'
+```
+
+## Usage
+
+First, enable the "Split Chunks" functionality in Webpack Encore:
+
+```diff
+// webpack.config.js
+// ...
+    .setOutputPath('public/build/')
+    .setPublicPath('/build')
+    .setManifestKeyPrefix('build/')
+
+    .addEntry('entry1', './assets/some_file.js')
+
++   .splitEntryChunks()
+// ...
+```
+
+When you enable `splitEntryChunks()`, instead of just needing 1 script tag
+for `entry1.js` and 1 link tag for `entry1.css`, you may now need *multiple*
+script and link tags. This is because Webpack ["splits" your files](https://webpack.js.org/plugins/split-chunks-plugin/)
+into smaller pieces for greater optimization. 
+
+To help with this, Encore writes a `entrypoints.json` file that contains
+all of the files needed for each "entry".
+
+For example, to render all of the `script` and `link` tags for a specific
+"entry" (e.g. `entry1`), you can:
+
+```twig
+{# any template or base layout where you need to include a JavaScript entry #}
+
+{% block javascripts %}
+    {{ parent() }}
+
+    {{ encore_entry_script_tags('entry1') }}
+{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+
+    {{ encore_entry_link_tags('entry1') }}
+{% endblock %}
+```
+
+Assuming that `entry1` required two files to be included - `build/vendor~entry1~entry2.js`
+and `build/entry1.js`, then `encore_entry_script_tags()` is equivalent to:
+
+```twig
+<script src="{{ asset('build/vendor~entry1~entry2.js') }}"></script>
+<script src="{{ asset('build/entry1.js') }}"></script>
+```
+
+If you want more control, you can use the `encore_entry_js_files()` and
+`encore_entry_css_files()` methods to get the list of files needed, then
+loop and create the `script` and `link` tags manually.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "symfony/webpack-encore-bundle",
+    "description": "Integration with your Symfony app & Webpack Encore!",
+    "type": "symfony-bundle",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Symfony\\WebpackEncoreBundle\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symfony\\WebpackEncoreBundle\\Tests\\": "tests/"
+        }
+    },
+    "require": {
+        "php": "^7.1.3",
+        "symfony/config": "^3.4 || ^4.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0",
+        "symfony/http-kernel": "^3.4 || ^4.0"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.13",
+        "symfony/asset": "^3.4 || ^4.0",
+        "symfony/framework-bundle": "^3.4 || ^4.0",
+        "symfony/phpunit-bridge": "^3.4 || ^4.1",
+        "symfony/twig-bundle": "^3.4 || ^4.0",
+        "twig/twig": "^1.35 || ^2.0"
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
+         backupGlobals="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory>.</directory>
+            <exclude>
+                <directory>tests</directory>
+                <directory>vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Asset;
+
+/**
+ * Returns the CSS or JavaScript files needed for a Webpack entry.
+ *
+ * This reads a JSON file with the format of Webpack Encore's entrypoints.json file.
+ *
+ * @final
+ */
+class EntrypointLookup
+{
+    private $entrypointJsonPath;
+
+    private $entriesData;
+
+    private $returnedFiles = [];
+
+    public function __construct(string $entrypointJsonPath)
+    {
+        $this->entrypointJsonPath = $entrypointJsonPath;
+    }
+
+    public function getJavaScriptFiles(string $entryName): array
+    {
+        return $this->getEntryFiles($entryName, 'js');
+    }
+
+    public function getCssFiles(string $entryName): array
+    {
+        return $this->getEntryFiles($entryName, 'css');
+    }
+
+    /**
+     * Resets the state of this service.
+     */
+    public function reset()
+    {
+        $this->returnedFiles = [];
+    }
+
+    private function getEntryFiles(string $entryName, string $key): array
+    {
+        $this->validateEntryName($entryName);
+        $entriesData = $this->getEntriesData();
+        $entryData = $entriesData[$entryName];
+
+        if (!isset($entryData[$key])) {
+            throw new \InvalidArgumentException(sprintf('Could not find "%s" key for the "%s" entry.', $key, $entryName));
+        }
+
+        // make sure to not return the same file multiple times
+        $entryFiles = $entryData[$key];
+        $newFiles = array_values(array_diff($entryFiles, $this->returnedFiles));
+        $this->returnedFiles = array_merge($this->returnedFiles, $newFiles);
+
+        return $newFiles;
+    }
+
+    private function validateEntryName(string $entryName)
+    {
+        $entriesData = $this->getEntriesData();
+        if (!isset($entriesData[$entryName])) {
+            $withoutExtension = substr($entryName, 0, strrpos($entryName, '.'));
+
+            if (isset($entriesData[$withoutExtension])) {
+                throw new \InvalidArgumentException(sprintf('Could not find the entry "%s". Try "%s" instead (without the extension).', $entryName, $withoutExtension));
+            }
+
+            throw new \InvalidArgumentException(sprintf('Could not find the entry "%s" in "%s". Found: %s.', $entryName, $this->entrypointJsonPath, implode(', ', array_keys($entriesData))));
+        }
+    }
+
+    private function getEntriesData(): array
+    {
+        if (null === $this->entriesData) {
+            if (!file_exists($this->entrypointJsonPath)) {
+                throw new \InvalidArgumentException(sprintf('Could not find the entrypoints file from Webpack: the file "%s" does not exist.', $this->entrypointJsonPath));
+            }
+
+            $this->entriesData = json_decode(file_get_contents($this->entrypointJsonPath), true);
+
+            if (null === $this->entriesData) {
+                throw new \InvalidArgumentException(sprintf('There was a problem JSON decoding the "%s" file', $this->entrypointJsonPath));
+            }
+        }
+
+        return $this->entriesData;
+    }
+}

--- a/src/Asset/ManifestLookup.php
+++ b/src/Asset/ManifestLookup.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Asset;
+
+/**
+ * Looks up values in Encore's `manifest.json` and returns them.
+ *
+ * @final
+ */
+class ManifestLookup
+{
+    private $manifestPath;
+    private $manifestData;
+
+    /**
+     * @param string $manifestPath Absolute path to the manifest.json file
+     */
+    public function __construct(string $manifestPath)
+    {
+        $this->manifestPath = $manifestPath;
+    }
+
+    public function getManifestPath(string $path): ?string
+    {
+        if (null === $this->manifestData) {
+            if (!file_exists($this->manifestPath)) {
+                throw new \RuntimeException(sprintf('Asset manifest file "%s" does not exist.', $this->manifestPath));
+            }
+
+            $this->manifestData = json_decode(file_get_contents($this->manifestPath), true);
+            if (JSON_ERROR_NONE !== json_last_error()) {
+                throw new \RuntimeException(sprintf('Error parsing JSON from asset manifest file "%s" - %s', $this->manifestPath, json_last_error_msg()));
+            }
+        }
+
+        return $this->manifestData[$path] ?? null;
+    }
+}

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Asset;
+
+use Symfony\Component\Asset\Packages;
+
+final class TagRenderer
+{
+    private $entrypointLookup;
+
+    private $manifestLookup;
+
+    private $packages;
+
+    public function __construct(EntrypointLookup $entrypointLookup, ManifestLookup $manifestLookup, Packages $packages = null)
+    {
+        $this->entrypointLookup = $entrypointLookup;
+        $this->manifestLookup = $manifestLookup;
+        $this->packages = $packages;
+    }
+
+    public function renderWebpackScriptTags(string $entryName, string $packageName = null): string
+    {
+        $scriptTags = [];
+        foreach ($this->entrypointLookup->getJavaScriptFiles($entryName) as $filename) {
+            $scriptTags[] = sprintf(
+                '<script src="%s"></script>',
+                htmlentities($this->getAssetPath($filename, $packageName))
+            );
+        }
+
+        return implode('', $scriptTags);
+    }
+
+    public function renderWebpackLinkTags(string $entryName, string $packageName = null): string
+    {
+        $scriptTags = [];
+        foreach ($this->entrypointLookup->getCssFiles($entryName) as $filename) {
+            $scriptTags[] = sprintf(
+                '<link rel="stylesheet" href="%s" />',
+                htmlentities($this->getAssetPath($filename, $packageName))
+            );
+        }
+
+        return implode('', $scriptTags);
+    }
+
+    private function getAssetPath(string $assetPath, string $packageName = null): string
+    {
+        if (null === $this->packages) {
+            throw new \Exception('To render the script or link tags, run "composer require symfony/asset".');
+        }
+
+        // to help avoid issues, use the manifest.json path always
+        $newAssetPath = $this->manifestLookup->getManifestPath($assetPath);
+
+        // could not find the path in manifest.json?
+        if (null === $newAssetPath) {
+            throw new \InvalidArgumentException(sprintf('The path "%s" could not be found in the Encore "manifest.json" file. This could be a problem with the dumped entrypoints.json file.', $assetPath));
+        }
+
+        return $this->packages->getUrl(
+            $newAssetPath,
+            $packageName
+        );
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+final class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('webpack_encore');
+        /** @var ArrayNodeDefinition $rootNode */
+        $rootNode = method_exists($treeBuilder, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('webpack_encore');
+
+        $rootNode
+            ->children()
+                ->scalarNode('output_path')
+                    ->isRequired()
+                    ->info('The path where Encore is building the assets - i.e. Encore.setOutputPath()')
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/WebpackEncoreExtension.php
+++ b/src/DependencyInjection/WebpackEncoreExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+final class WebpackEncoreExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
+        $loader->load('services.xml');
+
+        $configuration = $this->getConfiguration($configs, $container);
+        $config = $this->processConfiguration($configuration, $configs);
+
+        $container->getDefinition('webpack_encore.entrypoint_lookup')
+            ->replaceArgument(0, $config['output_path'].'/entrypoints.json');
+        $container->getDefinition('webpack_encore.manifest_lookup')
+            ->replaceArgument(0, $config['output_path'].'/manifest.json');
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <defaults public="false" />
+
+        <service id="webpack_encore.entrypoint_lookup" class="Symfony\WebpackEncoreBundle\Asset\EntrypointLookup">
+            <argument /> <!-- entrypoints.json path -->
+        </service>
+
+        <service id="webpack_encore.manifest_lookup" class="Symfony\WebpackEncoreBundle\Asset\ManifestLookup">
+            <argument /> <!-- manifest.json path -->
+        </service>
+
+        <service id="webpack_encore.tag_renderer" class="Symfony\WebpackEncoreBundle\Asset\TagRenderer">
+            <argument type="service" id="webpack_encore.entrypoint_lookup" />
+            <argument type="service" id="webpack_encore.manifest_lookup" />
+            <argument type="service" id="assets.packages" on-invalid="null" />
+        </service>
+
+        <service id="webpack_encore.twig_entry_files_extension" class="Symfony\WebpackEncoreBundle\Twig\EntryFilesTwigExtension">
+            <tag name="twig.extension" />
+            <argument type="service">
+                <service class="Symfony\Component\DependencyInjection\ServiceLocator">
+                    <tag name="container.service_locator" />
+                    <argument type="collection">
+                        <argument key="webpack_encore.entrypoint_lookup" type="service" id="webpack_encore.entrypoint_lookup" />
+                        <argument key="webpack_encore.manifest_lookup" type="service" id="webpack_encore.manifest_lookup" />
+                        <argument key="webpack_encore.tag_renderer" type="service" id="webpack_encore.tag_renderer" />
+                    </argument>
+                </service>
+            </argument>
+        </service>
+    </services>
+</container>

--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Twig;
+
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
+use Symfony\WebpackEncoreBundle\Asset\ManifestLookup;
+use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
+use Psr\Container\ContainerInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class EntryFilesTwigExtension extends AbstractExtension
+{
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('encore_entry_js_files', [$this, 'getWebpackJsFiles']),
+            new TwigFunction('encore_entry_css_files', [$this, 'getWebpackCssFiles']),
+            new TwigFunction('encore_entry_script_tags', [$this, 'renderWebpackScriptTags'], ['is_safe' => ['html']]),
+            new TwigFunction('encore_entry_link_tags', [$this, 'renderWebpackLinkTags'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function getWebpackJsFiles(string $entryName): array
+    {
+        $jsFiles = $this->getEntrypointLookup()
+            ->getJavaScriptFiles($entryName);
+
+        return array_map(function ($path) {
+            return $this->getManifestLookup()->getManifestPath($path);
+        }, $jsFiles);
+    }
+
+    public function getWebpackCssFiles(string $entryName): array
+    {
+        $cssFiles = $this->getEntrypointLookup()
+            ->getCssFiles($entryName);
+
+        return array_map(function ($path) {
+            return $this->getManifestLookup()->getManifestPath($path);
+        }, $cssFiles);
+    }
+
+    public function renderWebpackScriptTags(string $entryName, string $packageName = null): string
+    {
+        return $this->getTagRenderer()
+            ->renderWebpackScriptTags($entryName, $packageName);
+    }
+
+    public function renderWebpackLinkTags(string $entryName, string $packageName = null): string
+    {
+        return $this->getTagRenderer()
+            ->renderWebpackLinkTags($entryName, $packageName);
+    }
+
+    private function getEntrypointLookup(): EntrypointLookup
+    {
+        return $this->container->get('webpack_encore.entrypoint_lookup');
+    }
+
+    private function getManifestLookup(): ManifestLookup
+    {
+        return $this->container->get('webpack_encore.manifest_lookup');
+    }
+
+    private function getTagRenderer(): TagRenderer
+    {
+        return $this->container->get('webpack_encore.tag_renderer');
+    }
+}

--- a/src/WebpackEncoreBundle.php
+++ b/src/WebpackEncoreBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony MakerBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class WebpackEncoreBundle extends Bundle
+{
+}

--- a/tests/Asset/EntrypointLookupTest.php
+++ b/tests/Asset/EntrypointLookupTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\Tests\Asset;
+
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
+use PHPUnit\Framework\TestCase;
+
+class EntrypointLookupTest extends TestCase
+{
+    private $entrypointLookup;
+
+    private static $testJson = <<<EOF
+{
+  "my_entry": {
+    "js": [
+        "file1.js",
+        "file2.js"
+    ],
+    "css": [
+      "styles.css",
+      "styles2.css"
+    ]
+  },
+  "other_entry": {
+    "js": [
+        "file1.js",
+        "file3.js"
+    ],
+    "css": []
+  }
+}
+EOF;
+
+    public function setUp()
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'WebpackEncoreBundle');
+        file_put_contents($filename, self::$testJson);
+
+        $this->entrypointLookup = new EntrypointLookup($filename);
+    }
+
+    public function testGetJavaScriptFiles()
+    {
+        $this->assertEquals(
+            ['file1.js', 'file2.js'],
+            $this->entrypointLookup->getJavaScriptFiles('my_entry')
+        );
+    }
+
+    public function testGetJavaScriptFilesReturnsUniqueFilesOnly()
+    {
+        $this->assertEquals(
+            ['file1.js', 'file2.js'],
+            $this->entrypointLookup->getJavaScriptFiles('my_entry')
+        );
+
+        $this->assertEquals(
+            // file1.js is not returned - it was already returned above
+            ['file3.js'],
+            $this->entrypointLookup->getJavaScriptFiles('other_entry')
+        );
+    }
+
+    public function testGetCssFiles()
+    {
+        $this->assertEquals(
+            ['styles.css', 'styles2.css'],
+            $this->entrypointLookup->getCssFiles('my_entry')
+        );
+    }
+
+    public function testEmptyReturnOnValidEntryNoJsOrCssFile()
+    {
+        $this->assertEmpty(
+            $this->entrypointLookup->getCssFiles('other_entry')
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Could not find the entrypoints file
+     */
+    public function testExceptionOnBadFilename()
+    {
+        $entrypointLookup = new EntrypointLookup('fake_file');
+        $entrypointLookup->getCssFiles('anything');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Could not find the entry
+     */
+    public function testExceptionOnMissingEntry()
+    {
+        $this->entrypointLookup->getCssFiles('fake_entry');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Try "my_entry" instead
+     */
+    public function testExceptionOnEntryWithExtension()
+    {
+        $this->entrypointLookup->getJavaScriptFiles('my_entry.js');
+    }
+}

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\Tests\Asset;
+
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
+use Symfony\WebpackEncoreBundle\Asset\ManifestLookup;
+use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Packages;
+
+class TagRendererTest extends TestCase
+{
+    public function testRenderScriptTags()
+    {
+        $entrypointLookup = $this->createMock(EntrypointLookup::class);
+        $entrypointLookup->expects($this->once())
+            ->method('getJavaScriptFiles')
+            ->willReturn(['build/file1.js', 'build/file2.js']);
+
+        $manifestLookup = $this->createMock(ManifestLookup::class);
+        $manifestLookup->expects($this->exactly(2))
+            ->method('getManifestPath')
+            ->withConsecutive(
+                ['build/file1.js'],
+                ['build/file2.js']
+            )
+            ->willReturnCallback(function($path) {
+                return '/'.$path;
+            });
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->exactly(2))
+            ->method('getUrl')
+            ->withConsecutive(
+                ['/build/file1.js'],
+                ['/build/file2.js']
+            )
+            ->willReturnCallback(function($path) {
+                return 'http://localhost:8080'.$path;
+            });
+        $renderer = new TagRenderer($entrypointLookup, $manifestLookup, $packages);
+
+        $output = $renderer->renderWebpackScriptTags('my_entry', 'custom_package');
+        $this->assertContains(
+            '<script src="http://localhost:8080/build/file1.js"></script>',
+            $output
+        );
+        $this->assertContains(
+            '<script src="http://localhost:8080/build/file2.js"></script>',
+            $output
+        );
+    }
+
+    public function testRenderScriptTagsWithBadFilename()
+    {
+        $entrypointLookup = $this->createMock(EntrypointLookup::class);
+        $entrypointLookup->expects($this->once())
+            ->method('getJavaScriptFiles')
+            ->willReturn(['build/file<"bad_chars.js']);
+
+        $manifestLookup = $this->createMock(ManifestLookup::class);
+        $manifestLookup->expects($this->once())
+            ->method('getManifestPath')
+            ->willReturnCallback(function($path) {
+                return '/'.$path;
+            });
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->once())
+            ->method('getUrl')
+            ->willReturnCallback(function($path) {
+                return 'http://localhost:8080'.$path;
+            });
+        $renderer = new TagRenderer($entrypointLookup, $manifestLookup, $packages);
+
+        $output = $renderer->renderWebpackScriptTags('my_entry', 'custom_package');
+        $this->assertContains(
+            '<script src="http://localhost:8080/build/file&lt;&quot;bad_chars.js"></script>',
+            $output
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The path "foo/file1.js" could not be found in the Encore "manifest.json"
+     */
+    public function testBadAssetPrefixThrowException()
+    {
+        $entrypointLookup = $this->createMock(EntrypointLookup::class);
+        $entrypointLookup->expects($this->once())
+            ->method('getJavaScriptFiles')
+            ->willReturn(['foo/file1.js', 'bar/file2.js']);
+
+        $manifestLookup = $this->createMock(ManifestLookup::class);
+        $manifestLookup->expects($this->once())
+            ->method('getManifestPath')
+            ->willReturn(null);
+
+        $packages = $this->createMock(Packages::class);
+        $renderer = new TagRenderer($entrypointLookup, $manifestLookup, $packages);
+
+        $renderer->renderWebpackScriptTags('my_entry', 'custom_package');
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\Tests;
+
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+class IntegrationTest extends TestCase
+{
+    public function testTwigIntegration()
+    {
+        $kernel = new WebpackEncoreIntegrationTestKernel(true);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $html2 = $container->get('twig')->render('@integration_test/template.twig');
+        $this->assertContains(
+            '<script src="/build/file1.js"></script>',
+            $html2
+        );
+
+        $html2 = $container->get('twig')->render('@integration_test/manual_template.twig');
+        $this->assertContains(
+            '<script src="/build/file3.js"></script>',
+            $html2
+        );
+        // file1.js is not repeated
+        $this->assertNotContains(
+            '<script src="/build/file1.js"></script>',
+            $html2
+        );
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage composer require symfony/asset
+     */
+    public function testExceptionOnMissingAssets()
+    {
+        $kernel = new WebpackEncoreIntegrationTestKernel(false);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+        $container->get('twig')->render('@integration_test/template.twig');
+    }
+}
+
+class WebpackEncoreIntegrationTestKernel extends Kernel
+{
+    private $enableAssets;
+
+    public function __construct($enableAssets)
+    {
+        parent::__construct('test', true);
+        $this->enableAssets = $enableAssets;
+    }
+
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+            new TwigBundle(),
+            new WebpackEncoreBundle(),
+        ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function(ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'secret' => 'foo',
+                'assets' => [
+                    'enabled' => $this->enableAssets,
+                ],
+            ]);
+
+            $container->loadFromExtension('twig', [
+                'paths' => [
+                    __DIR__.'/fixtures' => 'integration_test'
+                ],
+                'strict_variables' => true,
+            ]);
+
+            $container->loadFromExtension('webpack_encore', [
+                'output_path' => __DIR__.'/fixtures/build',
+            ]);
+        });
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/cache'.spl_object_hash($this);
+    }
+
+    public function getLogDir()
+    {
+        return sys_get_temp_dir().'/logs'.spl_object_hash($this);
+    }
+}

--- a/tests/fixtures/build/entrypoints.json
+++ b/tests/fixtures/build/entrypoints.json
@@ -1,0 +1,19 @@
+{
+  "my_entry": {
+    "js": [
+        "build/file1.js",
+        "build/file2.js"
+    ],
+    "css": [
+      "build/styles.css",
+      "build/styles2.css"
+    ]
+  },
+  "other_entry": {
+    "js": [
+        "build/file1.js",
+        "build/file3.js"
+    ],
+    "css": []
+  }
+}

--- a/tests/fixtures/build/manifest.json
+++ b/tests/fixtures/build/manifest.json
@@ -1,0 +1,7 @@
+{
+  "build/file1.js": "/build/file1.js",
+  "build/file2.js": "/build/file2.js",
+  "build/file3.js": "/build/file3.js",
+  "build/styles.css": "/build/styles.css",
+  "build/styles2.css": "/build/styles2.css"
+}

--- a/tests/fixtures/manual_template.twig
+++ b/tests/fixtures/manual_template.twig
@@ -1,0 +1,7 @@
+{% for jsFile in encore_entry_js_files('other_entry') %}
+    <script src="{{ jsFile }}"></script>
+{% endfor %}
+
+{% for cssFile in encore_entry_css_files('other_entry') %}
+    <link rel="stylesheet" href="{{ cssFile }}" />
+{% endfor %}

--- a/tests/fixtures/template.twig
+++ b/tests/fixtures/template.twig
@@ -1,0 +1,2 @@
+{{ encore_entry_script_tags('my_entry') }}
+{{ encore_entry_link_tags('my_entry') }}


### PR DESCRIPTION
Hi guys!

This adds all the low-level details (composer, travis, etc) + the features themselves, which the README describes. Notes:

* Bundle supports PHP 7.1 and above

**Why this bundle?**

An optional feature in Webpack 4 allows Webpack to "split" an entry (e.g. `app.js`) into multiple, smaller files for performance. But, this means that you need multiple `<script>` tags for each entry... but these are dynamically created and changing. To help with that, Encore dumps a new `entrypoints.json` file, which describes which JS (or CSS) files are needed for each entry. This bundle adds a feature to read those. That's described in the README below (I'll likely move most of the README into the official docs).

Cheers!