### PR TITLE
Fix the issue where keys might be missing if no files are found by webpack plugin

### DIFF
--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -56,7 +56,8 @@ class EntrypointLookup
         $entryData = $entriesData[$entryName];
 
         if (!isset($entryData[$key])) {
-            throw new \InvalidArgumentException(sprintf('Could not find "%s" key for the "%s" entry.', $key, $entryName));
+            // If we don't find the file type then just send back nothing.
+            return [];
         }
 
         // make sure to not return the same file multiple times

--- a/tests/fixtures/build/entrypoints.json
+++ b/tests/fixtures/build/entrypoints.json
@@ -13,7 +13,6 @@
     "js": [
         "build/file1.js",
         "build/file3.js"
-    ],
-    "css": []
+    ]
   }
 }


### PR DESCRIPTION
Altered the entry point lookup to handle if a key is not found in the entry point file

This will fix issue #4 since we will now return a blank array if the file type is not found. This bug was caused by the swapping of plugins in the encore package that will now handle generating the entry points file. The new plugin will not put in a file type key if there none found.