### PR TITLE
Add a dependency on symfony/asset

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
     },
     "require": {
         "php": "^7.1.3",
+        "symfony/asset": "^3.4 || ^4.0",
         "symfony/config": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",
         "symfony/http-kernel": "^3.4 || ^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
-        "symfony/asset": "^3.4 || ^4.0",
         "symfony/framework-bundle": "^3.4 || ^4.0",
         "symfony/phpunit-bridge": "^3.4 || ^4.1",
         "symfony/twig-bundle": "^3.4 || ^4.0",

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -19,7 +19,7 @@ final class TagRenderer
 
     private $packages;
 
-    public function __construct(EntrypointLookup $entrypointLookup, ManifestLookup $manifestLookup, Packages $packages = null)
+    public function __construct(EntrypointLookup $entrypointLookup, ManifestLookup $manifestLookup, Packages $packages)
     {
         $this->entrypointLookup = $entrypointLookup;
         $this->manifestLookup = $manifestLookup;
@@ -54,10 +54,6 @@ final class TagRenderer
 
     private function getAssetPath(string $assetPath, string $packageName = null): string
     {
-        if (null === $this->packages) {
-            throw new \Exception('To render the script or link tags, run "composer require symfony/asset".');
-        }
-
         // to help avoid issues, use the manifest.json path always
         $newAssetPath = $this->manifestLookup->getManifestPath($assetPath);
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -18,7 +18,7 @@
         <service id="webpack_encore.tag_renderer" class="Symfony\WebpackEncoreBundle\Asset\TagRenderer">
             <argument type="service" id="webpack_encore.entrypoint_lookup" />
             <argument type="service" id="webpack_encore.manifest_lookup" />
-            <argument type="service" id="assets.packages" on-invalid="null" />
+            <argument type="service" id="assets.packages" />
         </service>
 
         <service id="webpack_encore.twig_entry_files_extension" class="Symfony\WebpackEncoreBundle\Twig\EntryFilesTwigExtension">

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -35,18 +35,6 @@ class IntegrationTest extends TestCase
             $html2
         );
     }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage composer require symfony/asset
-     */
-    public function testExceptionOnMissingAssets()
-    {
-        $kernel = new WebpackEncoreIntegrationTestKernel(false);
-        $kernel->boot();
-        $container = $kernel->getContainer();
-        $container->get('twig')->render('@integration_test/template.twig');
-    }
 }
 
 class WebpackEncoreIntegrationTestKernel extends Kernel


### PR DESCRIPTION
Hi guys!

I originally avoided a hard dependency on `symfony/asset`, but this adds it? Why:

1) It would allow us to abandon `symfony/webpack-encore-pack`... as we can now attach the recipe to this bundle and it will bring in the needed symfony/asset package

2) Needing to use Encore inside Symfony... but NOT wanting the `symfony/asset` component is a huge edge case. And if you're in that situation, it's trivial to implement your own system for loading `entrypoints.json`.

In short, this simplifies things!