### PR TITLE
Read data from an "entrypoints" key instead of the root of the entrypoints.json file

### DIFF
--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -51,7 +51,7 @@ class EntrypointLookup
     {
         $this->validateEntryName($entryName);
         $entriesData = $this->getEntriesData();
-        $entryData = $entriesData[$entryName];
+        $entryData = $entriesData['entrypoints'][$entryName];
 
         if (!isset($entryData[$key])) {
             // If we don't find the file type then just send back nothing.
@@ -69,10 +69,10 @@ class EntrypointLookup
     private function validateEntryName(string $entryName)
     {
         $entriesData = $this->getEntriesData();
-        if (!isset($entriesData[$entryName])) {
+        if (!isset($entriesData['entrypoints'][$entryName])) {
             $withoutExtension = substr($entryName, 0, strrpos($entryName, '.'));
 
-            if (isset($entriesData[$withoutExtension])) {
+            if (isset($entriesData['entrypoints'][$withoutExtension])) {
                 throw new \InvalidArgumentException(sprintf('Could not find the entry "%s". Try "%s" instead (without the extension).', $entryName, $withoutExtension));
             }
 
@@ -91,6 +91,10 @@ class EntrypointLookup
 
             if (null === $this->entriesData) {
                 throw new \InvalidArgumentException(sprintf('There was a problem JSON decoding the "%s" file', $this->entrypointJsonPath));
+            }
+
+            if (!isset($this->entriesData['entrypoints'])) {
+                throw new \InvalidArgumentException(sprintf('Could not find an "entrypoints" key in the "%s" file', $this->entrypointJsonPath));
             }
         }
 

--- a/tests/Asset/EntrypointLookupTest.php
+++ b/tests/Asset/EntrypointLookupTest.php
@@ -11,22 +11,24 @@ class EntrypointLookupTest extends TestCase
 
     private static $testJson = <<<EOF
 {
-  "my_entry": {
-    "js": [
-        "file1.js",
-        "file2.js"
-    ],
-    "css": [
-      "styles.css",
-      "styles2.css"
-    ]
-  },
-  "other_entry": {
-    "js": [
+  "entrypoints": {
+    "my_entry": {
+        "js": [
+          "file1.js",
+          "file2.js"
+        ],
+        "css": [
+          "styles.css",
+          "styles2.css"
+        ]
+    },
+    "other_entry": {
+      "js": [
         "file1.js",
         "file3.js"
-    ],
-    "css": []
+      ],
+      "css": []
+    }
   }
 }
 EOF;

--- a/tests/fixtures/build/entrypoints.json
+++ b/tests/fixtures/build/entrypoints.json
@@ -1,18 +1,20 @@
 {
-  "my_entry": {
-    "js": [
-        "build/file1.js",
-        "build/file2.js"
-    ],
-    "css": [
-      "build/styles.css",
-      "build/styles2.css"
-    ]
-  },
-  "other_entry": {
-    "js": [
-        "build/file1.js",
-        "build/file3.js"
-    ]
+  "entrypoints": {
+    "my_entry": {
+      "js": [
+          "build/file1.js",
+          "build/file2.js"
+      ],
+      "css": [
+        "build/styles.css",
+        "build/styles2.css"
+      ]
+    },
+    "other_entry": {
+      "js": [
+          "build/file1.js",
+          "build/file3.js"
+      ]
+    }
   }
 }


### PR DESCRIPTION
This PR changes how the `entrypoints.json` lookup works in order to support https://github.com/symfony/webpack-encore/pull/424.

Currently the entrypoints are directly listed at the root of the `entrypoints.json` file:

```json
{
  "my_entry": {
    "js": [
        "build/file1.js",
        "build/file2.js"
    ],
    "css": [
      "build/styles.css",
      "build/styles2.css"
    ]
  },
  "other_entry": {
    "js": [
        "build/file1.js",
        "build/file3.js"
    ]
  }
}
```

This works fine but will be a bit annoying later on if we want to add additional data such as [files hashes](https://github.com/symfony/webpack-encore/issues/418) that could be used to automatically handle the `integrity` attribute of the generated `<script>` tags.

A solution to that issue would be to move all the current data under an `entrypoints` key and add new keys when needed (for instance `hashes`):

```json
{
  "entrypoints": {
    "my_entry": {
      "js": [
          "build/file1.js",
          "build/file2.js"
      ],
      "css": [
        "build/styles.css",
        "build/styles2.css"
      ]
    },
    "other_entry": {
      "js": [
          "build/file1.js",
          "build/file3.js"
      ]
    }
  }
}
```