### PR TITLE
Don't self-close link tag

### DIFF
--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -41,7 +41,7 @@ final class TagRenderer
         $scriptTags = [];
         foreach ($this->entrypointLookup->getCssFiles($entryName) as $filename) {
             $scriptTags[] = sprintf(
-                '<link rel="stylesheet" href="%s" />',
+                '<link rel="stylesheet" href="%s">',
                 htmlentities($this->getAssetPath($filename, $packageName))
             );
         }

--- a/tests/fixtures/manual_template.twig
+++ b/tests/fixtures/manual_template.twig
@@ -3,5 +3,5 @@
 {% endfor %}
 
 {% for cssFile in encore_entry_css_files('other_entry') %}
-    <link rel="stylesheet" href="{{ asset(cssFile) }}" />
+    <link rel="stylesheet" href="{{ asset(cssFile) }}">
 {% endfor %}


### PR DESCRIPTION
Self-closing is only required by XHTML, invalid in HTML4 and optional in HTML5.
Nowadays, most of application are HTML5 so we should avoid it since it will save 2 chars from the output.