### PR TITLE
Allow to define multiple entrypoints and load assets from each of them.

### DIFF
--- a/src/Asset/EntrypointLookupCollection.php
+++ b/src/Asset/EntrypointLookupCollection.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Asset;
+
+use Symfony\WebpackEncoreBundle\Exception\UndefinedBuildException;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Aggregate the different entry points configured in the container.
+ *
+ * Retrieve the EntrypointLookup instance from the given key.
+ *
+ * @final
+ */
+class EntrypointLookupCollection
+{
+    private $buildEntrypoints;
+
+    public function __construct(ContainerInterface $buildEntrypoints)
+    {
+        $this->buildEntrypoints = $buildEntrypoints;
+    }
+
+    public function getEntrypointLookup(string $buildName): EntrypointLookupInterface
+    {
+        if (!$this->buildEntrypoints->has($buildName)) {
+            throw new UndefinedBuildException(sprintf('Given entry point "%s" is not configured', $buildName));
+        }
+
+        return $this->buildEntrypoints->get($buildName);
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@ namespace Symfony\WebpackEncoreBundle\DependencyInjection;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 
 final class Configuration implements ConfigurationInterface
 {
@@ -26,6 +27,19 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('output_path')
                     ->isRequired()
                     ->info('The path where Encore is building the assets - i.e. Encore.setOutputPath()')
+                ->end()
+                ->arrayNode('builds')
+                    ->useAttributeAsKey('name')
+                    ->scalarPrototype()
+                    ->validate()
+                        ->always(function ($values) {
+                            if (isset($values['_default'])) {
+                                throw new InvalidDefinitionException("Key '_default' can't be used as build name.");
+                            }
+
+                            return $values;
+                        })
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/DependencyInjection/WebpackEncoreExtension.php
+++ b/src/DependencyInjection/WebpackEncoreExtension.php
@@ -13,6 +13,10 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
 
 final class WebpackEncoreExtension extends Extension
 {
@@ -24,7 +28,23 @@ final class WebpackEncoreExtension extends Extension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
+        $factories = [
+            '_default' => new Reference($this->entrypointFactory($container, '_default', $config['output_path']))
+        ];
+        foreach ($config['builds'] as $name => $path) {
+            $factories[$name] = new Reference($this->entrypointFactory($container, $name, $path));
+        };
+
         $container->getDefinition('webpack_encore.entrypoint_lookup')
-            ->replaceArgument(0, $config['output_path'].'/entrypoints.json');
+            ->replaceArgument(0, $factories['_default']);
+        $container->getDefinition('webpack_encore.entrypoint_lookup_collection')
+            ->replaceArgument(0, ServiceLocatorTagPass::register($container, $factories));
+    }
+
+    private function entrypointFactory(ContainerBuilder $container, string $name, string $path): string
+    {
+        $id = sprintf('webpack_encore.entrypoint_lookup[%s]', $name);
+        $container->setDefinition($id, new Definition(EntrypointLookup::class, [$path.'/entrypoints.json']));
+        return $id;
     }
 }

--- a/src/Exception/UndefinedBuildException.php
+++ b/src/Exception/UndefinedBuildException.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Exception;
+
+class UndefinedBuildException extends \InvalidArgumentException
+{
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -10,9 +10,12 @@
         <service id="webpack_encore.entrypoint_lookup" class="Symfony\WebpackEncoreBundle\Asset\EntrypointLookup">
             <argument /> <!-- entrypoints.json path -->
         </service>
+        <service id="webpack_encore.entrypoint_lookup_collection" class="Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollection">
+            <argument /> <!-- build list of entrypoints path -->
+        </service>
 
         <service id="webpack_encore.tag_renderer" class="Symfony\WebpackEncoreBundle\Asset\TagRenderer">
-            <argument type="service" id="webpack_encore.entrypoint_lookup" />
+            <argument type="service" id="webpack_encore.entrypoint_lookup_collection" />
             <argument type="service" id="assets.packages" />
         </service>
 
@@ -23,6 +26,7 @@
                     <tag name="container.service_locator" />
                     <argument type="collection">
                         <argument key="webpack_encore.entrypoint_lookup" type="service" id="webpack_encore.entrypoint_lookup" />
+                        <argument key="webpack_encore.entrypoint_lookup_collection" type="service" id="webpack_encore.entrypoint_lookup_collection" />
                         <argument key="webpack_encore.tag_renderer" type="service" id="webpack_encore.tag_renderer" />
                     </argument>
                 </service>

--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -34,33 +34,34 @@ final class EntryFilesTwigExtension extends AbstractExtension
         ];
     }
 
-    public function getWebpackJsFiles(string $entryName): array
+    public function getWebpackJsFiles(string $entryName, string $entrypointName = '_default'): array
     {
-        return $this->getEntrypointLookup()
+        return $this->getEntrypointLookup($entrypointName)
             ->getJavaScriptFiles($entryName);
     }
 
-    public function getWebpackCssFiles(string $entryName): array
+    public function getWebpackCssFiles(string $entryName, string $entrypointName = '_default'): array
     {
-        return $this->getEntrypointLookup()
+        return $this->getEntrypointLookup($entrypointName)
             ->getCssFiles($entryName);
     }
 
-    public function renderWebpackScriptTags(string $entryName, string $packageName = null): string
+    public function renderWebpackScriptTags(string $entryName, string $packageName = null, string $entrypointName = '_default'): string
     {
         return $this->getTagRenderer()
-            ->renderWebpackScriptTags($entryName, $packageName);
+            ->renderWebpackScriptTags($entryName, $packageName, $entrypointName);
     }
 
-    public function renderWebpackLinkTags(string $entryName, string $packageName = null): string
+    public function renderWebpackLinkTags(string $entryName, string $packageName = null, string $entrypointName = '_default'): string
     {
         return $this->getTagRenderer()
-            ->renderWebpackLinkTags($entryName, $packageName);
+            ->renderWebpackLinkTags($entryName, $packageName, $entrypointName);
     }
 
-    private function getEntrypointLookup(): EntrypointLookupInterface
+    private function getEntrypointLookup(string $entrypointName): EntrypointLookupInterface
     {
-        return $this->container->get('webpack_encore.entrypoint_lookup');
+        return $this->container->get('webpack_encore.entrypoint_lookup_collection')
+            ->getEntrypointLookup($entrypointName);
     }
 
     private function getTagRenderer(): TagRenderer

--- a/tests/Asset/EntrypointLookupCollectionTest.php
+++ b/tests/Asset/EntrypointLookupCollectionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\Tests\Asset;
+
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollection;
+use PHPUnit\Framework\TestCase;
+
+class EntrypointLookupCollectionTest extends TestCase
+{
+    /**
+     * @expectedException Symfony\WebpackEncoreBundle\Exception\UndefinedBuildException
+     * @expectedExceptionMessage Given entry point "something" is not configured
+     */
+    public function testExceptionOnMissingEntry()
+    {
+        $collection = new EntrypointLookupCollection(new ServiceLocator([]));
+        $collection->getEntrypointLookup('something');
+    }
+}

--- a/tests/Asset/EntrypointLookupTest.php
+++ b/tests/Asset/EntrypointLookupTest.php
@@ -48,6 +48,18 @@ EOF;
             ['file1.js', 'file2.js'],
             $this->entrypointLookup->getJavaScriptFiles('my_entry')
         );
+
+        $this->assertEquals(
+            [],
+            $this->entrypointLookup->getJavaScriptFiles('my_entry')
+        );
+
+        $this->entrypointLookup->reset();
+
+        $this->assertEquals(
+            ['file1.js', 'file2.js'],
+            $this->entrypointLookup->getJavaScriptFiles('my_entry')
+        );
     }
 
     public function testGetJavaScriptFilesReturnsUniqueFilesOnly()
@@ -77,6 +89,32 @@ EOF;
         $this->assertEmpty(
             $this->entrypointLookup->getCssFiles('other_entry')
         );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageContains There was a problem JSON decoding the
+     */
+    public function testExceptionOnInvalidJson()
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'WebpackEncoreBundle');
+        file_put_contents($filename, "abcd");
+
+        $this->entrypointLookup = new EntrypointLookup($filename);
+        $this->entrypointLookup->getJavaScriptFiles('an_entry');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessageContains Could not find an "entrypoints" key in the
+     */
+    public function testExceptionOnMissingEntrypointsKeyInJson()
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'WebpackEncoreBundle');
+        file_put_contents($filename, "{}");
+
+        $this->entrypointLookup = new EntrypointLookup($filename);
+        $this->entrypointLookup->getJavaScriptFiles('an_entry');
     }
 
     /**

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -5,6 +5,7 @@ namespace Symfony\WebpackEncoreBundle\Tests\Asset;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollection;
 use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
 
 class TagRendererTest extends TestCase
@@ -15,6 +16,11 @@ class TagRendererTest extends TestCase
         $entrypointLookup->expects($this->once())
             ->method('getJavaScriptFiles')
             ->willReturn(['/build/file1.js', '/build/file2.js']);
+        $entrypointCollection = $this->createMock(EntrypointLookupCollection::class);
+        $entrypointCollection->expects($this->once())
+            ->method('getEntrypointLookup')
+            ->withConsecutive(['_default'])
+            ->will($this->onConsecutiveCalls($entrypointLookup));
 
         $packages = $this->createMock(Packages::class);
         $packages->expects($this->exactly(2))
@@ -26,7 +32,7 @@ class TagRendererTest extends TestCase
             ->willReturnCallback(function($path) {
                 return 'http://localhost:8080'.$path;
             });
-        $renderer = new TagRenderer($entrypointLookup, $packages);
+        $renderer = new TagRenderer($entrypointCollection, $packages);
 
         $output = $renderer->renderWebpackScriptTags('my_entry', 'custom_package');
         $this->assertContains(
@@ -45,6 +51,11 @@ class TagRendererTest extends TestCase
         $entrypointLookup->expects($this->once())
             ->method('getJavaScriptFiles')
             ->willReturn(['/build/file<"bad_chars.js']);
+        $entrypointCollection = $this->createMock(EntrypointLookupCollection::class);
+        $entrypointCollection->expects($this->once())
+            ->method('getEntrypointLookup')
+            ->withConsecutive(['_default'])
+            ->will($this->onConsecutiveCalls($entrypointLookup));
 
         $packages = $this->createMock(Packages::class);
         $packages->expects($this->once())
@@ -52,7 +63,7 @@ class TagRendererTest extends TestCase
             ->willReturnCallback(function($path) {
                 return 'http://localhost:8080'.$path;
             });
-        $renderer = new TagRenderer($entrypointLookup, $packages);
+        $renderer = new TagRenderer($entrypointCollection, $packages);
 
         $output = $renderer->renderWebpackScriptTags('my_entry', 'custom_package');
         $this->assertContains(
@@ -60,4 +71,61 @@ class TagRendererTest extends TestCase
             $output
         );
     }
+
+    public function testRenderScriptTagsWithinAnEntryPointCollection()
+    {
+        $entrypointLookup = $this->createMock(EntrypointLookupInterface::class);
+        $entrypointLookup->expects($this->once())
+            ->method('getJavaScriptFiles')
+            ->willReturn(['/build/file1.js']);
+
+        $secondEntrypointLookup = $this->createMock(EntrypointLookupInterface::class);
+        $secondEntrypointLookup->expects($this->once())
+            ->method('getJavaScriptFiles')
+            ->willReturn(['/build/file2.js']);
+        $thirdEntrypointLookup = $this->createMock(EntrypointLookupInterface::class);
+        $thirdEntrypointLookup->expects($this->once())
+            ->method('getJavaScriptFiles')
+            ->willReturn(['/build/file3.js']);
+
+        $entrypointCollection = $this->createMock(EntrypointLookupCollection::class);
+        $entrypointCollection->expects($this->exactly(3))
+            ->method('getEntrypointLookup')
+            ->withConsecutive(['_default'], ['second'], ['third'])
+            ->will($this->onConsecutiveCalls(
+                $entrypointLookup,
+                $secondEntrypointLookup,
+                $thirdEntrypointLookup
+            ));
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->exactly(3))
+            ->method('getUrl')
+            ->withConsecutive(
+                ['/build/file1.js', 'custom_package'],
+                ['/build/file2.js', null],
+                ['/build/file3.js', 'specific_package']
+            )
+            ->willReturnCallback(function($path) {
+                return 'http://localhost:8080'.$path;
+            });
+        $renderer = new TagRenderer($entrypointCollection, $packages);
+
+        $output = $renderer->renderWebpackScriptTags('my_entry', 'custom_package');
+        $this->assertContains(
+            '<script src="http://localhost:8080/build/file1.js"></script>',
+            $output
+        );
+        $output = $renderer->renderWebpackScriptTags('my_entry', null, 'second');
+        $this->assertContains(
+            '<script src="http://localhost:8080/build/file2.js"></script>',
+            $output
+        );
+        $output = $renderer->renderWebpackScriptTags('my_entry', 'specific_package', 'third');
+        $this->assertContains(
+            '<script src="http://localhost:8080/build/file3.js"></script>',
+            $output
+        );
+    }
+
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -18,12 +18,44 @@ class IntegrationTest extends TestCase
         $kernel->boot();
         $container = $kernel->getContainer();
 
-        $html2 = $container->get('twig')->render('@integration_test/template.twig');
+        $html1 = $container->get('twig')->render('@integration_test/template.twig');
         $this->assertContains(
             '<script src="/build/file1.js"></script>',
-            $html2
+            $html1
+        );
+        $this->assertContains(
+            '<link rel="stylesheet" href="/build/styles.css">'.
+            '<link rel="stylesheet" href="/build/styles2.css">',
+            $html1
+        );
+        $this->assertContains(
+            '<script src="/build/other3.js"></script>',
+            $html1
+        );
+        $this->assertContains(
+            '<link rel="stylesheet" href="/build/styles3.css">'.
+            '<link rel="stylesheet" href="/build/styles4.css">',
+            $html1
         );
 
+        $html2 = $container->get('twig')->render('@integration_test/manual_template.twig');
+        $this->assertContains(
+            '<script src="/build/file3.js"></script>',
+            $html2
+        );
+        $this->assertContains(
+            '<script src="/build/other4.js"></script>',
+            $html2
+        );
+    }
+
+    public function testEntriesAreNotRepeteadWhenAlreadyOutputIntegration()
+    {
+        $kernel = new WebpackEncoreIntegrationTestKernel(true);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $html1 = $container->get('twig')->render('@integration_test/template.twig');
         $html2 = $container->get('twig')->render('@integration_test/manual_template.twig');
         $this->assertContains(
             '<script src="/build/file3.js"></script>',
@@ -32,6 +64,16 @@ class IntegrationTest extends TestCase
         // file1.js is not repeated
         $this->assertNotContains(
             '<script src="/build/file1.js"></script>',
+            $html2
+        );
+        // styles3.css is not repeated
+        $this->assertNotContains(
+            '<link rel="stylesheet" href="/build/styles3.css">',
+            $html2
+        );
+        // styles4.css is not repeated
+        $this->assertNotContains(
+            '<link rel="stylesheet" href="/build/styles4.css">',
             $html2
         );
     }
@@ -75,6 +117,9 @@ class WebpackEncoreIntegrationTestKernel extends Kernel
 
             $container->loadFromExtension('webpack_encore', [
                 'output_path' => __DIR__.'/fixtures/build',
+                'builds' => [
+                    'different_build' =>  __DIR__.'/fixtures/different_build'
+                ]
             ]);
         });
     }

--- a/tests/fixtures/different_build/entrypoints.json
+++ b/tests/fixtures/different_build/entrypoints.json
@@ -1,0 +1,22 @@
+{
+  "entrypoints": {
+    "third_entry": {
+      "js": [
+          "build/other3.js"
+      ],
+      "css": [
+        "build/styles3.css",
+        "build/styles4.css"
+      ]
+    },
+    "next_entry": {
+      "js": [
+          "build/other4.js"
+      ],
+      "css": [
+        "build/styles3.css",
+        "build/styles4.css"
+      ]
+    }
+  }
+}

--- a/tests/fixtures/manual_template.twig
+++ b/tests/fixtures/manual_template.twig
@@ -5,3 +5,11 @@
 {% for cssFile in encore_entry_css_files('other_entry') %}
     <link rel="stylesheet" href="{{ asset(cssFile) }}">
 {% endfor %}
+
+{% for jsFile in encore_entry_js_files('next_entry', 'different_build') %}
+    <script src="{{ asset(jsFile) }}"></script>
+{% endfor %}
+
+{% for cssFile in encore_entry_css_files('next_entry', 'different_build') %}
+    <link rel="stylesheet" href="{{ asset(cssFile) }}" />
+{% endfor %}

--- a/tests/fixtures/template.twig
+++ b/tests/fixtures/template.twig
@@ -1,2 +1,4 @@
 {{ encore_entry_script_tags('my_entry') }}
 {{ encore_entry_link_tags('my_entry') }}
+{{ encore_entry_script_tags('third_entry', null, 'different_build') }}
+{{ encore_entry_link_tags('third_entry', null, 'different_build') }}


### PR DESCRIPTION
This PR is added to fix the issue #13. With that new code, you can configure your project like this : 

```yaml
webpack_encore:
    # the "default" build
    output_path: '%kernel.project_dir%/public/build'
    builds:
        frontend: '%kernel.project_dir%/public/frontend/build'
```

Then in your Twig template : 

```twig
{{ encore_entry_script_tags('entry1', 'frontend') }}
```