### PR TITLE
Remove trailing slash on link tag

### DIFF
--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -41,7 +41,7 @@ final class TagRenderer
         $scriptTags = [];
         foreach ($this->entrypointLookup->getCssFiles($entryName) as $filename) {
             $scriptTags[] = sprintf(
-                '<link rel="stylesheet" href="%s" />',
+                '<link rel="stylesheet" href="%s">',
                 htmlentities($this->getAssetPath($filename, $packageName))
             );
         }


### PR DESCRIPTION
Though allowed, generally in HTML5 it's written without it. Based on the style of <script> tag, I'm guessing the bundle isn't supporting anything but HTML5.