### PR TITLE
Catch error with entrypointlookups in sub-requests

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
+use Twig_Error_Runtime;
+
+class ExceptionListener
+{
+    private $entrypointLookup;
+
+    public function __construct(EntrypointLookup $entrypointLookup)
+    {
+        $this->entrypointLookup = $entrypointLookup;
+    }
+
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $exception = $event->getException();
+
+        // Reset the entrypointLookup list of previously returned entries, as Twig_Error_Runtime will initialise a sub-request
+        if ($exception instanceof Twig_Error_Runtime) {
+            $this->entrypointLookup->reset();
+        }
+    }
+}

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -9,10 +9,11 @@
 
 namespace Symfony\WebpackEncoreBundle\EventListener;
 
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
+use Twig_Error_Runtime;
 
-class RequestListener
+class ExceptionListener
 {
     private $entrypointLookup;
 
@@ -21,10 +22,12 @@ class RequestListener
         $this->entrypointLookup = $entrypointLookup;
     }
 
-    public function onKernelRequest(GetResponseEvent $event)
+    public function onKernelException(GetResponseForExceptionEvent $event)
     {
-        if (!$event->isMasterRequest()) {
-            // reset the entrypointLookup list of previously returned entries for subrequests sub-request
+        $exception = $event->getException();
+
+        // Reset the entrypointLookup list of previously returned entries, as Twig_Error_Runtime will initialise a sub-request
+        if ($exception instanceof Twig_Error_Runtime) {
             $this->entrypointLookup->reset();
         }
     }

--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -9,11 +9,10 @@
 
 namespace Symfony\WebpackEncoreBundle\EventListener;
 
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
-use Twig_Error_Runtime;
 
-class ExceptionListener
+class RequestListener
 {
     private $entrypointLookup;
 
@@ -22,12 +21,10 @@ class ExceptionListener
         $this->entrypointLookup = $entrypointLookup;
     }
 
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelRequest(GetResponseEvent $event)
     {
-        $exception = $event->getException();
-
-        // Reset the entrypointLookup list of previously returned entries, as Twig_Error_Runtime will initialise a sub-request
-        if ($exception instanceof Twig_Error_Runtime) {
+        if (!$event->isMasterRequest()) {
+            // reset the entrypointLookup list of previously returned entries for subrequests sub-request
             $this->entrypointLookup->reset();
         }
     }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -11,6 +11,11 @@
             <argument /> <!-- entrypoints.json path -->
         </service>
 
+        <service id="webpack_encore.exceptionlistener" class="Symfony\WebpackEncoreBundle\EventListener\ExceptionListener">
+            <argument type="service" id="webpack_encore.entrypoint_lookup" />
+            <tag name="kernel.event_listener" event="kernel.request" />
+        </service>
+
         <service id="webpack_encore.tag_renderer" class="Symfony\WebpackEncoreBundle\Asset\TagRenderer">
             <argument type="service" id="webpack_encore.entrypoint_lookup" />
             <argument type="service" id="assets.packages" />

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -11,9 +11,9 @@
             <argument /> <!-- entrypoints.json path -->
         </service>
 
-        <service id="webpack_encore.requestlistener" class="Symfony\WebpackEncoreBundle\EventListener\RequestListener">
+        <service id="webpack_encore.exceptionlistener" class="Symfony\WebpackEncoreBundle\EventListener\ExceptionListener">
             <argument type="service" id="webpack_encore.entrypoint_lookup" />
-            <tag name="kernel.event_listener" event="kernel.request" />
+            <tag name="kernel.event_listener" event="kernel.exception" />
         </service>
 
         <service id="webpack_encore.tag_renderer" class="Symfony\WebpackEncoreBundle\Asset\TagRenderer">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -11,9 +11,9 @@
             <argument /> <!-- entrypoints.json path -->
         </service>
 
-        <service id="webpack_encore.exceptionlistener" class="Symfony\WebpackEncoreBundle\EventListener\ExceptionListener">
+        <service id="webpack_encore.requestlistener" class="Symfony\WebpackEncoreBundle\EventListener\RequestListener">
             <argument type="service" id="webpack_encore.entrypoint_lookup" />
-            <tag name="kernel.event_listener" event="kernel.exception" />
+            <tag name="kernel.event_listener" event="kernel.request" />
         </service>
 
         <service id="webpack_encore.tag_renderer" class="Symfony\WebpackEncoreBundle\Asset\TagRenderer">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -13,7 +13,7 @@
 
         <service id="webpack_encore.exceptionlistener" class="Symfony\WebpackEncoreBundle\EventListener\ExceptionListener">
             <argument type="service" id="webpack_encore.entrypoint_lookup" />
-            <tag name="kernel.event_listener" event="kernel.request" />
+            <tag name="kernel.event_listener" event="kernel.exception" />
         </service>
 
         <service id="webpack_encore.tag_renderer" class="Symfony\WebpackEncoreBundle\Asset\TagRenderer">


### PR DESCRIPTION
In EntrypointLookup, the list of previously returned entries is not reset
on sub-requests.
This leads to errors when sub-requests return full html pages.

Fixes symfony/demo#910