### PR TITLE
Tweak docs: Now .splitEntryChunks() is enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ webpack_encore:
 
 ## Usage
 
-First, enable the "Split Chunks" functionality in Webpack Encore:
+The "Split Chunks" functionality in Webpack Encore is enabled by default
+with the recipe if you install this bundle using Symfony Flex. Otherwise,
+enable it manually:
 
 ```diff
 // webpack.config.js


### PR DESCRIPTION
Now it's already enabled in the recipe, see https://github.com/symfony/recipes/pull/509
