### PR TITLE
Extend from the ResetInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "symfony/asset": "^3.4 || ^4.0",
         "symfony/config": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",
-        "symfony/http-kernel": "^3.4 || ^4.0"
+        "symfony/http-kernel": "^3.4 || ^4.0",
+        "symfony/contracts": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",

--- a/src/Asset/EntrypointLookupInterface.php
+++ b/src/Asset/EntrypointLookupInterface.php
@@ -9,9 +9,10 @@
 
 namespace Symfony\WebpackEncoreBundle\Asset;
 
+use Symfony\Contracts\Service\ResetInterface;
 use Symfony\WebpackEncoreBundle\Exception\EntrypointNotFoundException;
 
-interface EntrypointLookupInterface
+interface EntrypointLookupInterface extends ResetInterface
 {
     /**
      * @throws EntrypointNotFoundException if an entry name is passed that does not exist in entrypoints.json


### PR DESCRIPTION
This way the Container automaticly resets the returnedFile array and this hack is obsolete https://github.com/php-pm/php-pm-httpkernel/pull/151