### PR TITLE
Fix webpack_encore.entrypoint_lookup registration

### DIFF
--- a/src/DependencyInjection/WebpackEncoreExtension.php
+++ b/src/DependencyInjection/WebpackEncoreExtension.php
@@ -36,7 +36,7 @@ final class WebpackEncoreExtension extends Extension
         };
 
         $container->getDefinition('webpack_encore.entrypoint_lookup')
-            ->replaceArgument(0, $factories['_default']);
+            ->replaceArgument(0, $config['output_path'].'/entrypoints.json');
         $container->getDefinition('webpack_encore.entrypoint_lookup_collection')
             ->replaceArgument(0, ServiceLocatorTagPass::register($container, $factories));
     }

--- a/tests/DependencyInjection/DummyService.php
+++ b/tests/DependencyInjection/DummyService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\Tests\DependencyInjection;
+
+
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
+
+class DummyService
+{
+    protected $entryPointLookup;
+
+    public function __construct(EntrypointLookup $entrypointLookup)
+    {
+        $this->entryPointLookup = $entrypointLookup;
+    }
+
+    public function getEntryPointLookup(): EntrypointLookup
+    {
+        return $this->entryPointLookup;
+    }
+}

--- a/tests/DependencyInjection/ServiceRegistrationTest.php
+++ b/tests/DependencyInjection/ServiceRegistrationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\Tests\DependencyInjection;
+
+
+use PHPUnit\Framework\TestCase;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
+
+class ServiceRegistrationTest extends TestCase
+{
+    public function dataProvider_testLookupServicesCanBeAliased()
+    {
+        return [
+            'lookup' => ['test.lookup', EntrypointLookup::class],
+            'lookup_default' => ['test.lookup_default', EntrypointLookup::class],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider_testLookupServicesCanBeAliased
+     */
+    public function testLookupServicesCanBeAliased(string $id, string $class)
+    {
+        $kernel = new WebpackEncoreServicesTestKernel(__DIR__.'/../fixtures/config/services.xml');
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $this->assertTrue($container->has($id));
+
+        $service = $container->get($id);
+        $this->assertInstanceOf($class, $service);
+    }
+
+
+    public function dataProvider_testLookupServicesCanBeInjected()
+    {
+        return [
+            'dummy1 (with webpack_encore.entrypoint_lookup injected)' => ['test.dummy1'],
+            'dummy2 (with webpack_encore.entrypoint_lookup[_default] injected)' => ['test.dummy2'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider_testLookupServicesCanBeInjected
+     */
+    public function testLookupServicesCanBeInjected(string $id)
+    {
+        $kernel = new WebpackEncoreServicesTestKernel(__DIR__.'/../fixtures/config/services_injection.xml');
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $this->assertTrue($container->has($id));
+
+        /** @var DummyService $service */
+        $service = $container->get($id);
+        $this->assertInstanceOf(DummyService::class, $service);
+
+        $injectedLookupService = $service->getEntryPointLookup();
+        $this->assertInstanceOf(EntrypointLookup::class, $injectedLookupService);
+    }
+
+}

--- a/tests/DependencyInjection/WebpackEncoreServicesTestKernel.php
+++ b/tests/DependencyInjection/WebpackEncoreServicesTestKernel.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\Tests\DependencyInjection;
+
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+
+class WebpackEncoreServicesTestKernel extends Kernel
+{
+    protected $servicesDefinitionPath;
+
+    public function __construct(string $servicesDefinitionPath)
+    {
+        parent::__construct('test', true);
+        $this->servicesDefinitionPath = $servicesDefinitionPath;
+    }
+
+    public function registerBundles()
+    {
+        return [
+            new FrameworkBundle(),
+            new WebpackEncoreBundle(),
+        ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(function (ContainerBuilder $container) use ($loader) {
+            $container->loadFromExtension('framework', [
+                'secret' => 'foo',
+            ]);
+
+            $container->loadFromExtension('webpack_encore', [
+                'output_path' => __DIR__.'/../fixtures/build',
+            ]);
+        });
+
+        $loader->load($this->servicesDefinitionPath);
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/cache'.spl_object_hash($this);
+    }
+
+    public function getLogDir()
+    {
+        return sys_get_temp_dir().'/logs'.spl_object_hash($this);
+    }
+}

--- a/tests/fixtures/config/services.xml
+++ b/tests/fixtures/config/services.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <defaults public="true"/>
+
+        <service id="test.lookup" alias="webpack_encore.entrypoint_lookup"/>
+        <service id="test.lookup_default" alias="webpack_encore.entrypoint_lookup[_default]"/>
+    </services>
+</container>

--- a/tests/fixtures/config/services_injection.xml
+++ b/tests/fixtures/config/services_injection.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <defaults public="true"/>
+
+        <service id="test.dummy1" class="Symfony\WebpackEncoreBundle\Tests\DependencyInjection\DummyService">
+            <argument type="service" id="webpack_encore.entrypoint_lookup"/>
+        </service>
+        <service id="test.dummy2" class="Symfony\WebpackEncoreBundle\Tests\DependencyInjection\DummyService">
+            <argument type="service" id="webpack_encore.entrypoint_lookup[_default]"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
The `webpack_encore.entrypoint_lookup` service instanciation was throwing an exception, preventing it from being used properly with dependency injection.

Closes #36 