### PR TITLE
Use normalizeKeys(false) for builds config

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('builds')
                     ->useAttributeAsKey('name')
+                    ->normalizeKeys(false)
                     ->scalarPrototype()
                     ->validate()
                         ->always(function ($values) {


### PR DESCRIPTION
Fix for #40 to allow dashes in the build names.
