### PR TITLE
Add support for integrity hashes

### DIFF
--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -18,7 +18,7 @@ use Symfony\WebpackEncoreBundle\Exception\EntrypointNotFoundException;
  *
  * @final
  */
-class EntrypointLookup implements EntrypointLookupInterface
+class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProviderInterface
 {
     private $entrypointJsonPath;
 
@@ -39,6 +39,17 @@ class EntrypointLookup implements EntrypointLookupInterface
     public function getCssFiles(string $entryName): array
     {
         return $this->getEntryFiles($entryName, 'css');
+    }
+
+    public function getIntegrityData(): array
+    {
+        $entriesData = $this->getEntriesData();
+
+        if (!array_key_exists('integrity', $entriesData)) {
+            return [];
+        }
+
+        return $entriesData['integrity'];
     }
 
     /**

--- a/src/Asset/IntegrityDataProviderInterface.php
+++ b/src/Asset/IntegrityDataProviderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Asset;
+
+interface IntegrityDataProviderInterface
+{
+    public function getIntegrityData(): array;
+}

--- a/src/Asset/IntegrityDataProviderInterface.php
+++ b/src/Asset/IntegrityDataProviderInterface.php
@@ -11,5 +11,19 @@ namespace Symfony\WebpackEncoreBundle\Asset;
 
 interface IntegrityDataProviderInterface
 {
+    /**
+     * Returns a map of integrity hashes indexed by asset paths.
+     *
+     * If multiples hashes are defined for a given asset they must
+     * be separated by a space.
+     *
+     * For instance:
+     * [
+     *    'path/to/file1.js' => 'sha384-Q86c+opr0lBUPWN28BLJFqmLhho+9ZcJpXHorQvX6mYDWJ24RQcdDarXFQYN8HLc',
+     *    'path/to/styles.css' => 'sha384-ymG7OyjISWrOpH9jsGvajKMDEOP/mKJq8bHC0XdjQA6P8sg2nu+2RLQxcNNwE/3J',
+     * ]
+     *
+     * @return string[]
+     */
     public function getIntegrityData(): array;
 }

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -42,10 +42,27 @@ final class TagRenderer
     public function renderWebpackScriptTags(string $entryName, string $packageName = null, string $entrypointName = '_default'): string
     {
         $scriptTags = [];
-        foreach ($this->getEntrypointLookup($entrypointName)->getJavaScriptFiles($entryName) as $filename) {
+        $entryPointLookup = $this->getEntrypointLookup($entrypointName);
+        $integrityHashes = ($entryPointLookup instanceof IntegrityDataProviderInterface) ? $entryPointLookup->getIntegrityData() : [];
+
+        foreach ($entryPointLookup->getJavaScriptFiles($entryName) as $filename) {
+            $attributes = [
+                'src' => $this->getAssetPath($filename, $packageName),
+            ];
+
+            if (!empty($integrityHashes[$filename])) {
+                $attributes['integrity'] = $integrityHashes[$filename];
+            }
+
             $scriptTags[] = sprintf(
-                '<script src="%s"></script>',
-                htmlentities($this->getAssetPath($filename, $packageName))
+                '<script %s></script>',
+                implode(' ', array_map(
+                    function ($key, $value) {
+                        return sprintf('%s="%s"', $key, htmlentities($value));
+                    },
+                    array_keys($attributes),
+                    $attributes
+                ))
             );
         }
 
@@ -55,10 +72,28 @@ final class TagRenderer
     public function renderWebpackLinkTags(string $entryName, string $packageName = null, string $entrypointName = '_default'): string
     {
         $scriptTags = [];
-        foreach ($this->getEntrypointLookup($entrypointName)->getCssFiles($entryName) as $filename) {
+        $entryPointLookup = $this->getEntrypointLookup($entrypointName);
+        $integrityHashes = ($entryPointLookup instanceof IntegrityDataProviderInterface) ? $entryPointLookup->getIntegrityData() : [];
+
+        foreach ($entryPointLookup->getCssFiles($entryName) as $filename) {
+            $attributes = [
+                'rel' => 'stylesheet',
+                'href' => $this->getAssetPath($filename, $packageName),
+            ];
+
+            if (!empty($integrityHashes[$filename])) {
+                $attributes['integrity'] = $integrityHashes[$filename];
+            }
+
             $scriptTags[] = sprintf(
-                '<link rel="stylesheet" href="%s">',
-                htmlentities($this->getAssetPath($filename, $packageName))
+                '<link %s>',
+                implode(' ', array_map(
+                    function ($key, $value) {
+                        return sprintf('%s="%s"', $key, htmlentities($value));
+                    },
+                    array_keys($attributes),
+                    $attributes
+                ))
             );
         }
 

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -50,19 +50,13 @@ final class TagRenderer
                 'src' => $this->getAssetPath($filename, $packageName),
             ];
 
-            if (!empty($integrityHashes[$filename])) {
+            if (isset($integrityHashes[$filename])) {
                 $attributes['integrity'] = $integrityHashes[$filename];
             }
 
             $scriptTags[] = sprintf(
                 '<script %s></script>',
-                implode(' ', array_map(
-                    function ($key, $value) {
-                        return sprintf('%s="%s"', $key, htmlentities($value));
-                    },
-                    array_keys($attributes),
-                    $attributes
-                ))
+                $this->convertArrayToAttributes($attributes)
             );
         }
 
@@ -81,19 +75,13 @@ final class TagRenderer
                 'href' => $this->getAssetPath($filename, $packageName),
             ];
 
-            if (!empty($integrityHashes[$filename])) {
+            if (isset($integrityHashes[$filename])) {
                 $attributes['integrity'] = $integrityHashes[$filename];
             }
 
             $scriptTags[] = sprintf(
                 '<link %s>',
-                implode(' ', array_map(
-                    function ($key, $value) {
-                        return sprintf('%s="%s"', $key, htmlentities($value));
-                    },
-                    array_keys($attributes),
-                    $attributes
-                ))
+                $this->convertArrayToAttributes($attributes)
             );
         }
 
@@ -115,5 +103,16 @@ final class TagRenderer
     private function getEntrypointLookup(string $buildName): EntrypointLookupInterface
     {
         return $this->entrypointLookupCollection->getEntrypointLookup($buildName);
+    }
+
+    private function convertArrayToAttributes(array $attributesMap): string
+    {
+        return implode(' ', array_map(
+            function ($key, $value) {
+                return sprintf('%s="%s"', $key, htmlentities($value));
+            },
+            array_keys($attributesMap),
+            $attributesMap
+        ));
     }
 }

--- a/tests/Asset/EntrypointLookupTest.php
+++ b/tests/Asset/EntrypointLookupTest.php
@@ -30,6 +30,10 @@ class EntrypointLookupTest extends TestCase
       ],
       "css": []
     }
+  },
+  "integrity": {
+    "file1.js": "sha384-Q86c+opr0lBUPWN28BLJFqmLhho+9ZcJpXHorQvX6mYDWJ24RQcdDarXFQYN8HLc",
+    "styles.css": "sha384-ymG7OyjISWrOpH9jsGvajKMDEOP/mKJq8bHC0XdjQA6P8sg2nu+2RLQxcNNwE/3J"
   }
 }
 EOF;
@@ -89,6 +93,23 @@ EOF;
         $this->assertEmpty(
             $this->entrypointLookup->getCssFiles('other_entry')
         );
+    }
+
+    public function testGetIntegrityData()
+    {
+        $this->assertEquals([
+            'file1.js' => 'sha384-Q86c+opr0lBUPWN28BLJFqmLhho+9ZcJpXHorQvX6mYDWJ24RQcdDarXFQYN8HLc',
+            'styles.css' => 'sha384-ymG7OyjISWrOpH9jsGvajKMDEOP/mKJq8bHC0XdjQA6P8sg2nu+2RLQxcNNwE/3J',
+        ], $this->entrypointLookup->getIntegrityData());
+    }
+
+    public function testMissingIntegrityData()
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'WebpackEncoreBundle');
+        file_put_contents($filename, '{ "entrypoints": { "other_entry": { "js": { } } } }');
+
+        $this->entrypointLookup = new EntrypointLookup($filename);
+        $this->assertEquals([], $this->entrypointLookup->getIntegrityData());
     }
 
     /**

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -20,12 +20,12 @@ class IntegrationTest extends TestCase
 
         $html1 = $container->get('twig')->render('@integration_test/template.twig');
         $this->assertContains(
-            '<script src="/build/file1.js"></script>',
+            '<script src="/build/file1.js" integrity="sha384-Q86c+opr0lBUPWN28BLJFqmLhho+9ZcJpXHorQvX6mYDWJ24RQcdDarXFQYN8HLc"></script>',
             $html1
         );
         $this->assertContains(
-            '<link rel="stylesheet" href="/build/styles.css">'.
-            '<link rel="stylesheet" href="/build/styles2.css">',
+            '<link rel="stylesheet" href="/build/styles.css" integrity="sha384-4g+Zv0iELStVvA4/B27g4TQHUMwZttA5TEojjUyB8Gl5p7sarU4y+VTSGMrNab8n">' .
+            '<link rel="stylesheet" href="/build/styles2.css" integrity="sha384-hfZmq9+2oI5Cst4/F4YyS2tJAAYdGz7vqSMP8cJoa8bVOr2kxNRLxSw6P8UZjwUn">',
             $html1
         );
         $this->assertContains(

--- a/tests/fixtures/build/entrypoints.json
+++ b/tests/fixtures/build/entrypoints.json
@@ -16,5 +16,12 @@
           "build/file3.js"
       ]
     }
+  },
+  "integrity": {
+    "build/file1.js": "sha384-Q86c+opr0lBUPWN28BLJFqmLhho+9ZcJpXHorQvX6mYDWJ24RQcdDarXFQYN8HLc",
+    "build/file2.js": "sha384-ymG7OyjISWrOpH9jsGvajKMDEOP/mKJq8bHC0XdjQA6P8sg2nu+2RLQxcNNwE/3J",
+    "build/styles.css": "sha384-4g+Zv0iELStVvA4/B27g4TQHUMwZttA5TEojjUyB8Gl5p7sarU4y+VTSGMrNab8n",
+    "build/styles2.css": "sha384-hfZmq9+2oI5Cst4/F4YyS2tJAAYdGz7vqSMP8cJoa8bVOr2kxNRLxSw6P8UZjwUn",
+    "build/file3.js": "sha384-ZU3hiTN/+Va9WVImPi+cI0/j/Q7SzAVezqL1aEXha8sVgE5HU6/0wKUxj1LEnkC9"
   }
 }


### PR DESCRIPTION
This PR allows to automatically add `integrity` attributes on `<script>` and `<link>` tags based on the content of the `entrypoints.json` file (related to the following PR on Encore: https://github.com/symfony/webpack-encore/pull/522).

It requires the following configuration:

```js
// webpack.config.js
// Enable it for all builds with the
// default hash algorithm (sha384)
Encore.enableIntegrityHashes();

// Or enable it only in production
// with a custom hash algorithm
Encore.enableIntegrityHashes(
    Encore.isProduction(),
    'sha384'
);

// Or with multiple hash algorithms
Encore.enableIntegrityHashes(
    Encore.isProduction(),
    ['sha384','sha512']
);
```

Then, calling `yarn encore` then generates an entrypoints.json that contains hashes for all the files it references:

```js
{
  "entrypoints": {
    // (...)
  },
  "integrity": {
    "/build/runtime.fa8f03f5.js": "sha384-5WSgDNxkAY6j6/bzAcp3v//+PCXLgXCU3u5QgRXWiRfMnN4Ic/a/EF6HJnbRXik8",
    "/build/0.b70b772e.js": "sha384-FA3+8ecenjmV1Y751s0fKxGBNtyLBA8hDY4sqFoqvsCPOamLlA5ckhRBttBg1esp",
    // (...)
  }
}
```

And these hashes are automatically added when calling `encore_entry_script_tags` and `encore_entry_link_tags`:

```html
<html lang="en">
  <head>
    <!-- ... -->
    <link rel="stylesheet" href="/build/css/app.2235bc2d.css" integrity="sha384-Jmd35HF93DFCXjisVeMi6U3lniH/mOdAF6wLtOMqhYMh2ZiBRUdtF7jXB55IAKfm">
    <!-- ... -->
  </head>
  <body id="homepage">
    <!-- ... -->
    <script src="/build/runtime.fa8f03f5.js" integrity="sha384-5WSgDNxkAY6j6/bzAcp3v//+PCXLgXCU3u5QgRXWiRfMnN4Ic/a/EF6HJnbRXik8"></script>
    <script src="/build/0.b70b772e.js" integrity="sha384-FA3+8ecenjmV1Y751s0fKxGBNtyLBA8hDY4sqFoqvsCPOamLlA5ckhRBttBg1esp"></script>
    <!-- ... -->
  </body>
</html>
```

An example using Symfony Demo can be found here: https://github.com/Lyrkan/symfony-demo/commit/91a06cd