### PR TITLE
Fixing tests for old PHPUnit versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ matrix:
     fast_finish: true
     include:
         - php: 7.1
+          env: SYMFONY_PHPUNIT_VERSION=7.4
         - php: 7.1
-          env: deps=high
+          env: deps=high SYMFONY_PHPUNIT_VERSION=7.4
         - php: 7.2
           env: deps=low
         - php: 7.3


### PR DESCRIPTION
There is an incorrect deprecation warning in an old version of PHPUnit. The PHPUnit Bridge 4.3 will fix this (by using a newer version of PHPUnit). To fix it for us, we can force PHP 7.1 to use a newer version.