### PR TITLE
Builds cache keys are improperly composed

### DIFF
--- a/src/DependencyInjection/WebpackEncoreExtension.php
+++ b/src/DependencyInjection/WebpackEncoreExtension.php
@@ -20,6 +20,8 @@ use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
 
 final class WebpackEncoreExtension extends Extension
 {
+    private const ENTRYPOINTS_FILE_NAME = 'entrypoints.json';
+
     public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, new FileLocator(\dirname(__DIR__).'/Resources/config'));
@@ -32,11 +34,11 @@ final class WebpackEncoreExtension extends Extension
             '_default' => $this->entrypointFactory($container, '_default', $config['output_path'], $config['cache']),
         ];
         $cacheKeys = [
-            '_default' => $config['output_path'].'/entrypoints.json',
+            '_default' => $config['output_path'].'/'.self::ENTRYPOINTS_FILE_NAME,
         ];
         foreach ($config['builds'] as $name => $path) {
             $factories[$name] = $this->entrypointFactory($container, $name, $path, $config['cache']);
-            $cacheKeys[rawurlencode($name)] = $path;
+            $cacheKeys[rawurlencode($name)] = $path.'/'.self::ENTRYPOINTS_FILE_NAME;
         }
 
         $container->getDefinition('webpack_encore.entrypoint_lookup.cache_warmer')
@@ -49,7 +51,7 @@ final class WebpackEncoreExtension extends Extension
     private function entrypointFactory(ContainerBuilder $container, string $name, string $path, bool $cacheEnabled): Reference
     {
         $id = sprintf('webpack_encore.entrypoint_lookup[%s]', $name);
-        $arguments = [$path.'/entrypoints.json', $cacheEnabled ? new Reference('webpack_encore.cache') : null, $name];
+        $arguments = [$path.'/'.self::ENTRYPOINTS_FILE_NAME, $cacheEnabled ? new Reference('webpack_encore.cache') : null, $name];
         $container->setDefinition($id, new Definition(EntrypointLookup::class, $arguments));
 
         return new Reference($id);


### PR DESCRIPTION
Looks like ba327cd5b9e7876f4b151e154c221e1f05b06db8 has an issue with `builds` configuration. I have my app configures to use multiple builds:
```yaml
webpack_encore:
    output_path: "%kernel.project_dir%/web/assets/build"
    builds:
        custom_build: "%kernel.project_dir%/web/assets/custom_build/build"
```

which was failing on `cache:clear`:
```
In EntrypointLookup.php line 111:
                                                                                                                   
  [InvalidArgumentException]                                                                                       
  There was a problem JSON decoding the "/Users/maciejkobus/Projects/ezplatform/web/assets/custom_build/build" file  
```

To my understanding it is trying to parse directory as a JSON and indeed it looks like cache keys are improperly combined in the Extension class.