### PR TITLE
Run php-cs-fixer over the bundle using preexisting .php_cs.dist rules

### DIFF
--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -50,7 +50,7 @@ class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProvid
     {
         $entriesData = $this->getEntriesData();
 
-        if (!array_key_exists('integrity', $entriesData)) {
+        if (!\array_key_exists('integrity', $entriesData)) {
             return [];
         }
 

--- a/src/Asset/EntrypointLookupCollectionInterface.php
+++ b/src/Asset/EntrypointLookupCollectionInterface.php
@@ -16,7 +16,7 @@ interface EntrypointLookupCollectionInterface
     /**
      * Retrieve the EntrypointLookupInterface for the given build.
      *
-     * @throws UndefinedBuildException If the build does not exist.
+     * @throws UndefinedBuildException if the build does not exist
      */
     public function getEntrypointLookup(string $buildName = null): EntrypointLookupInterface;
 }

--- a/tests/Asset/EntrypointLookupCollectionTest.php
+++ b/tests/Asset/EntrypointLookupCollectionTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\WebpackEncoreBundle\Tests\Asset;
 
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -10,7 +17,7 @@ use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
 class EntrypointLookupCollectionTest extends TestCase
 {
     /**
-     * @expectedException Symfony\WebpackEncoreBundle\Exception\UndefinedBuildException
+     * @expectedException \Symfony\WebpackEncoreBundle\Exception\UndefinedBuildException
      * @expectedExceptionMessage The build "something" is not configured
      */
     public function testExceptionOnMissingEntry()
@@ -20,7 +27,7 @@ class EntrypointLookupCollectionTest extends TestCase
     }
 
     /**
-     * @expectedException Symfony\WebpackEncoreBundle\Exception\UndefinedBuildException
+     * @expectedException \Symfony\WebpackEncoreBundle\Exception\UndefinedBuildException
      * @expectedExceptionMessage There is no default build configured: please pass an argument to getEntrypointLookup().
      */
     public function testExceptionOnMissingDefaultBuildEntry()
@@ -32,7 +39,7 @@ class EntrypointLookupCollectionTest extends TestCase
     public function testDefaultBuildIsReturned()
     {
         $lookup = $this->createMock(EntrypointLookupInterface::class);
-        $collection = new EntrypointLookupCollection(new ServiceLocator(['the_default' => function() use ($lookup) { return $lookup; }]), 'the_default');
+        $collection = new EntrypointLookupCollection(new ServiceLocator(['the_default' => function () use ($lookup) { return $lookup; }]), 'the_default');
 
         $this->assertSame($lookup, $collection->getEntrypointLookup());
     }

--- a/tests/Asset/EntrypointLookupTest.php
+++ b/tests/Asset/EntrypointLookupTest.php
@@ -1,12 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\WebpackEncoreBundle\Tests\Asset;
 
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
 use PHPUnit\Framework\TestCase;
-use Symfony\WebpackEncoreBundle\Exception\EntrypointNotFoundException;
 
 class EntrypointLookupTest extends TestCase
 {
@@ -121,7 +126,7 @@ EOF;
     public function testExceptionOnInvalidJson()
     {
         $filename = tempnam(sys_get_temp_dir(), 'WebpackEncoreBundle');
-        file_put_contents($filename, "abcd");
+        file_put_contents($filename, 'abcd');
 
         $this->entrypointLookup = new EntrypointLookup($filename);
         $this->entrypointLookup->getJavaScriptFiles('an_entry');
@@ -134,7 +139,7 @@ EOF;
     public function testExceptionOnMissingEntrypointsKeyInJson()
     {
         $filename = tempnam(sys_get_temp_dir(), 'WebpackEncoreBundle');
-        file_put_contents($filename, "{}");
+        file_put_contents($filename, '{}');
 
         $this->entrypointLookup = new EntrypointLookup($filename);
         $this->entrypointLookup->getJavaScriptFiles('an_entry');
@@ -151,7 +156,7 @@ EOF;
     }
 
     /**
-     * @expectedException Symfony\WebpackEncoreBundle\Exception\EntrypointNotFoundException
+     * @expectedException \Symfony\WebpackEncoreBundle\Exception\EntrypointNotFoundException
      * @expectedExceptionMessage Could not find the entry
      */
     public function testExceptionOnMissingEntry()
@@ -160,7 +165,7 @@ EOF;
     }
 
     /**
-     * @expectedException Symfony\WebpackEncoreBundle\Exception\EntrypointNotFoundException
+     * @expectedException \Symfony\WebpackEncoreBundle\Exception\EntrypointNotFoundException
      * @expectedExceptionMessage Try "my_entry" instead
      */
     public function testExceptionOnEntryWithExtension()

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\WebpackEncoreBundle\Tests\Asset;
 
 use PHPUnit\Framework\TestCase;
@@ -30,7 +37,7 @@ class TagRendererTest extends TestCase
                 ['/build/file1.js', 'custom_package'],
                 ['/build/file2.js', 'custom_package']
             )
-            ->willReturnCallback(function($path) {
+            ->willReturnCallback(function ($path) {
                 return 'http://localhost:8080'.$path;
             });
         $renderer = new TagRenderer($entrypointCollection, $packages);
@@ -61,7 +68,7 @@ class TagRendererTest extends TestCase
         $packages = $this->createMock(Packages::class);
         $packages->expects($this->once())
             ->method('getUrl')
-            ->willReturnCallback(function($path) {
+            ->willReturnCallback(function ($path) {
                 return 'http://localhost:8080'.$path;
             });
         $renderer = new TagRenderer($entrypointCollection, $packages);
@@ -107,7 +114,7 @@ class TagRendererTest extends TestCase
                 ['/build/file2.js', null],
                 ['/build/file3.js', 'specific_package']
             )
-            ->willReturnCallback(function($path) {
+            ->willReturnCallback(function ($path) {
                 return 'http://localhost:8080'.$path;
             });
         $renderer = new TagRenderer($entrypointCollection, $packages);
@@ -158,7 +165,7 @@ class TagRendererTest extends TestCase
                 ['/build/file2.js', 'custom_package']
             )
             ->willReturnCallback(function ($path) {
-                return 'http://localhost:8080' . $path;
+                return 'http://localhost:8080'.$path;
             });
         $renderer = new TagRenderer($entrypointCollection, $packages, true);
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\WebpackEncoreBundle\Tests;
 
 use Symfony\Component\DependencyInjection\Reference;
@@ -28,7 +35,7 @@ class IntegrationTest extends TestCase
             $html1
         );
         $this->assertContains(
-            '<link rel="stylesheet" href="/build/styles.css" integrity="sha384-4g+Zv0iELStVvA4/B27g4TQHUMwZttA5TEojjUyB8Gl5p7sarU4y+VTSGMrNab8n">' .
+            '<link rel="stylesheet" href="/build/styles.css" integrity="sha384-4g+Zv0iELStVvA4/B27g4TQHUMwZttA5TEojjUyB8Gl5p7sarU4y+VTSGMrNab8n">'.
             '<link rel="stylesheet" href="/build/styles2.css" integrity="sha384-hfZmq9+2oI5Cst4/F4YyS2tJAAYdGz7vqSMP8cJoa8bVOr2kxNRLxSw6P8UZjwUn">',
             $html1
         );
@@ -129,7 +136,7 @@ class WebpackEncoreIntegrationTestKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(function(ContainerBuilder $container) {
+        $loader->load(function (ContainerBuilder $container) {
             $container->loadFromExtension('framework', [
                 'secret' => 'foo',
                 'assets' => [
@@ -139,7 +146,7 @@ class WebpackEncoreIntegrationTestKernel extends Kernel
 
             $container->loadFromExtension('twig', [
                 'paths' => [
-                    __DIR__.'/fixtures' => 'integration_test'
+                    __DIR__.'/fixtures' => 'integration_test',
                 ],
                 'strict_variables' => true,
             ]);
@@ -148,8 +155,8 @@ class WebpackEncoreIntegrationTestKernel extends Kernel
                 'output_path' => __DIR__.'/fixtures/build',
                 'cache' => true,
                 'builds' => [
-                    'different_build' =>  __DIR__.'/fixtures/different_build'
-                ]
+                    'different_build' => __DIR__.'/fixtures/different_build',
+                ],
             ]);
 
             $container->register(WebpackEncoreCacheWarmerTester::class)


### PR DESCRIPTION
Manually enforce php_cs rules over /src and /tests

```
~/build/vendor/symfony/webpack-encore-bundle(patch-1 ✗) php-cs-fixer fix --config=.php_cs.dist -vvv .
Loaded config default from ".php_cs.dist".
Using cache file ".php_cs.cache".
Paths from configuration file have been overridden by paths provided as command arguments.
FFFFS.FSSFSSS..SS
Legend: ?-unknown, I-invalid file syntax, file ignored, S-Skipped, .-no changes, F-fixed, E-error
   1) tests/Asset/EntrypointLookupTest.php (single_quote, php_unit_fqcn_annotation, no_unused_imports, header_comment)
   2) tests/Asset/EntrypointLookupCollectionTest.php (function_declaration, php_unit_fqcn_annotation, header_comment)
   3) tests/Asset/TagRendererTest.php (concat_space, function_declaration, header_comment)
   4) tests/IntegrationTest.php (concat_space, trailing_comma_in_multiline_array, function_declaration, header_comment, binary_operator_spaces)
   5) src/Asset/EntrypointLookupCollectionInterface.php (phpdoc_annotation_without_dot)
   6) src/Asset/EntrypointLookup.php (native_function_invocation)

Fixed all files in 0.318 seconds, 12.000 MB memory used
```