### PR TITLE
Only add alias to EntrypointLookupInterface if default build is enabled

### DIFF
--- a/src/DependencyInjection/WebpackEncoreExtension.php
+++ b/src/DependencyInjection/WebpackEncoreExtension.php
@@ -50,7 +50,10 @@ final class WebpackEncoreExtension extends Extension
 
         $container->getDefinition('webpack_encore.entrypoint_lookup_collection')
             ->replaceArgument(0, ServiceLocatorTagPass::register($container, $factories));
-        $container->setAlias(EntrypointLookupInterface::class, new Alias($this->getEntrypointServiceId('_default')));
+
+        if (false !== $config['output_path']) {
+            $container->setAlias(EntrypointLookupInterface::class, new Alias($this->getEntrypointServiceId('_default')));
+        }
     }
 
     private function entrypointFactory(ContainerBuilder $container, string $name, string $path, bool $cacheEnabled): Reference


### PR DESCRIPTION
Caused by the combination of https://github.com/symfony/webpack-encore-bundle/commit/64f1e94140cbcc58beb4199ddc9633d8be15a4e2 and #37

The commit in question was added after the commits in my PR #37, so it slipped through the cracks.