### PR TITLE
[Contracts] Update dependency to use symfony/service-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/config": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",
         "symfony/http-kernel": "^3.4 || ^4.0",
-        "symfony/contracts": "^1.0"
+        "symfony/service-contracts": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",


### PR DESCRIPTION
Updated requirement symfony/contracts to symfony/service-contracts so having this bundle in a Symfony 4.3 installation does not generate ambiguous classes with an optimized composer autoloader.

Fixes #64