### PR TITLE
Reset default EntrypointLookup on exception to fix #21 and #73

### DIFF
--- a/src/DependencyInjection/WebpackEncoreExtension.php
+++ b/src/DependencyInjection/WebpackEncoreExtension.php
@@ -49,6 +49,9 @@ final class WebpackEncoreExtension extends Extension
             $cacheKeys[rawurlencode($name)] = $path.'/'.self::ENTRYPOINTS_FILE_NAME;
         }
 
+        $container->getDefinition('webpack_encore.exception_listener')
+            ->replaceArgument(1, array_keys($factories));
+
         $container->getDefinition('webpack_encore.entrypoint_lookup.cache_warmer')
             ->replaceArgument(0, $cacheKeys);
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\EventListener;
+
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollection;
+
+class ExceptionListener
+{
+    private $entrypointLookupCollection;
+
+    private $buildNames;
+
+    public function __construct(EntrypointLookupCollection $entrypointLookupCollection, array $buildNames)
+    {
+        $this->entrypointLookupCollection = $entrypointLookupCollection;
+        $this->buildNames = $buildNames;
+    }
+
+    public function onKernelException()
+    {
+        foreach ($this->buildNames as $buildName) {
+            $this->entrypointLookupCollection->getEntrypointLookup($buildName)->reset();
+        }
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -50,6 +50,12 @@
             <tag name="cache.pool" />
         </service>
 
+        <service id="webpack_encore.exception_listener" class="Symfony\WebpackEncoreBundle\EventListener\ExceptionListener">
+            <tag name="kernel.event_listener" event="kernel.exception" />
+            <argument type="service" id="webpack_encore.entrypoint_lookup_collection" />
+            <argument /> <!-- build list of build names -->
+        </service>
+
         <service id="webpack_encore.preload_assets_event_listener" class="Symfony\WebpackEncoreBundle\EventListener\PreLoadAssetsEventListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="webpack_encore.tag_renderer" />

--- a/tests/EventListener/ExceptionListenerTest.php
+++ b/tests/EventListener/ExceptionListenerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Tests\EventListener;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollection;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
+use Symfony\WebpackEncoreBundle\EventListener\ExceptionListener;
+
+class ExceptionListenerTest extends TestCase
+{
+    public function testItResetsAllEntrypointLookups()
+    {
+        /** @var EntrypointLookupInterface[]|Prophecy\Prophecy\ObjectProphecy[] $entrypointLookups */
+        $entrypointLookups = [];
+        $entrypointLookupsValueMap = [];
+
+        $buildNames = ['_default', '_test'];
+        foreach ($buildNames as $buildName) {
+            $entrypointLookups[$buildName] = $this->createMock(EntrypointLookupInterface::class);
+            $entrypointLookups[$buildName]->expects($this->once())->method('reset');
+
+            $entrypointLookupsValueMap[] = [$buildName, $entrypointLookups[$buildName]];
+        }
+
+        $entrypointLookupCollection = $this->createMock(EntrypointLookupCollection::class);
+        $entrypointLookupCollection->method('getEntrypointLookup')
+            ->willReturnMap($entrypointLookupsValueMap);
+
+        $request = new Request();
+        $exception = new \Exception();
+        $event = new GetResponseForExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $exception
+        );
+        $listener = new ExceptionListener($entrypointLookupCollection, $buildNames);
+        $listener->onKernelException($event);
+    }
+}


### PR DESCRIPTION
Since @ckrack seems to be unavailable to continue working on #21, I figured this would be faster :)

I don't like having `_default` hardcoded in the listener, but I see no other options right now.
I thought about adding a `resetAll()` method to EntrypointLookupCollection, but there were a couple of issues with that:
1. It would either be a BC break if I added it to the interface, or an important method that isn't interfaced and I don't really like either of those.
2. I couldn't even implement it because the container that we get in the collection only has `has()` and `get()` methods, so I couldn't go through it. This would also have to be replaced (and break BC) to implement `resetAll()`.

Fixes https://github.com/symfony/demo/issues/910