### PR TITLE
Fix Travis SYMFONY_REQUIRE config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,16 +28,15 @@ matrix:
 before_install:
     - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
     - if ! [ -z "$STABILITY" ]; then composer config minimum-stability ${STABILITY}; fi;
-    - if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;
-    - composer install
-
-install:
     - |
       # Install symfony/flex
       if [[ $deps = low ]]; then
           export SYMFONY_REQUIRE='>=2.3'
       fi
       composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
+
+install:
+    - composer install
     - ./vendor/bin/simple-phpunit install
 
 script:


### PR DESCRIPTION
The `composer install` script was running in `before_install`, while the `SYMFONY_REQUIRE` + symfony/flex was configured in `install`. Swapping these two from position fixes the Travis setup. (flex has to be configured before `composer install`).

I also removed `if ! [ -v "$DEPENDENCIES" ]; then composer require --no-update ${DEPENDENCIES}; fi;`, it seems to be a left over from previously used configs as the `DEPENDENCIES` is not defined anywhere.