### PR TITLE
Add new functions to disable "file tracking" & ease inline_css usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,9 @@
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
         "symfony/phpunit-bridge": "^4.3.5 || ^5.0",
         "symfony/twig-bundle": "^3.4 || ^4.0 || ^5.0",
-        "symfony/web-link": "^3.4 || ^4.0 || ^5.0"
+        "symfony/web-link": "^3.4 || ^4.0 || ^5.0",
+        "twig/extra-bundle": "3.x-dev",
+        "twig/cssinliner-extra": "3.x-dev"
     },
     "extra": {
         "thanks": {

--- a/src/Asset/BuildFileLocator.php
+++ b/src/Asset/BuildFileLocator.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\Asset;
+
+/**
+ * Attempts to read the source of built files.
+ *
+ * @internal
+ */
+final class BuildFileLocator
+{
+    private $buildPaths;
+
+    private $ensureFileExists = true;
+
+    /**
+     * @param string[] $buildPaths
+     */
+    public function __construct(array $buildPaths)
+    {
+        $this->buildPaths = $buildPaths;
+    }
+
+    public function findFile(string $path, string $buildName = '_default'): string
+    {
+        if (!isset($this->buildPaths[$buildName])) {
+            throw new \InvalidArgumentException(sprintf('Invalid build name "%s"', $buildName));
+        }
+
+        // sanity / security check
+        if (!$this->strEndsWith($path, '.css') && !$this->strEndsWith($path, '.js')) {
+            throw new \InvalidArgumentException('Can only read files ending in .css and .js');
+        }
+
+        $buildPath = $this->buildPaths[$buildName];
+
+        $targetPath = $this->combinePaths($buildPath, $path);
+
+        if ($this->ensureFileExists && !file_exists($targetPath)) {
+            throw new \LogicException(sprintf('Cannot determine how to locate the "%s" file by combining with the output_path "%s". Looked in "%s".', $path, $buildPath, $targetPath));
+        }
+
+        return $targetPath;
+    }
+
+    /**
+     * This method tries to combine the build path and asset path to get a final path.
+     *
+     * It's really an "attempt" and will work in all normal cases, but not
+     * in all cases. For example with this config:
+     *
+     *      output_path: %kernel.project_dir%/public/build
+     *
+     * If you pass an asset whose path is "build/file1.js", this would
+     * remove the duplicated "build" on both and return a final path of:
+     *
+     *      %kernel.project_dir%/public/build/file1.js
+     */
+    private function combinePaths(string $buildPath, string $path): string
+    {
+        $pathParts = explode('/', ltrim($path, '/'));
+        $buildPathInfo = new \SplFileInfo($buildPath);
+
+        while (true) {
+            // break if there are no directories left
+            if (count($pathParts) == 1) {
+                break;
+            }
+
+            // break if the beginning of the path and the "directory name" of the build path
+            // don't intersect
+            if ($pathParts[0] !== $buildPathInfo->getFilename()) {
+                break;
+            }
+
+            // pop the first "directory" off of the path
+            unset($pathParts[0]);
+            $pathParts = array_values($pathParts);
+        }
+
+        return $buildPathInfo->getPathname().'/'.implode('/', $pathParts);
+    }
+
+    private function strEndsWith(string $haystack, string $needle): bool
+    {
+        return '' === $needle || $needle === \substr($haystack, -\strlen($needle));
+    }
+
+    /**
+     * @internal
+     */
+    public function disableFileExistsCheck(): void
+    {
+        $this->ensureFileExists = false;
+    }
+}

--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -33,6 +33,8 @@ class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProvid
 
     private $strictMode;
 
+    private $trackReturnedFiles = true;
+
     public function __construct(string $entrypointJsonPath, CacheItemPoolInterface $cache = null, string $cacheKey = null, bool $strictMode = true)
     {
         $this->entrypointJsonPath = $entrypointJsonPath;
@@ -70,6 +72,18 @@ class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProvid
         $this->returnedFiles = [];
     }
 
+    /**
+     * Can be used to disable file tracking.
+     *
+     * When file tracking is disabled, *all* CSS and JS files will be
+     * returned from getJavaScriptFiles() and getCssFiles() including
+     * those that were previously returned.
+     */
+    public function enableReturnedFileTracking(bool $shouldTrackReturnedFiles)
+    {
+        $this->trackReturnedFiles = $shouldTrackReturnedFiles;
+    }
+
     private function getEntryFiles(string $entryName, string $key): array
     {
         $this->validateEntryName($entryName);
@@ -81,8 +95,14 @@ class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProvid
             return [];
         }
 
-        // make sure to not return the same file multiple times
         $entryFiles = $entryData[$key];
+
+        // if tracking is disabled, return everything & do not mutate returnedFiles list
+        if (!$this->trackReturnedFiles) {
+            return $entryFiles;
+        }
+
+        // make sure to not return the same file multiple times
         $newFiles = array_values(array_diff($entryFiles, $this->returnedFiles));
         $this->returnedFiles = array_merge($this->returnedFiles, $newFiles);
 

--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -84,6 +84,11 @@ class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProvid
         $this->trackReturnedFiles = $shouldTrackReturnedFiles;
     }
 
+    public function isReturnedFileTrackingEnabled(): bool
+    {
+        return $this->trackReturnedFiles;
+    }
+
     private function getEntryFiles(string $entryName, string $key): array
     {
         $this->validateEntryName($entryName);

--- a/src/DependencyInjection/WebpackEncoreExtension.php
+++ b/src/DependencyInjection/WebpackEncoreExtension.php
@@ -35,10 +35,12 @@ final class WebpackEncoreExtension extends Extension
 
         $factories = [];
         $cacheKeys = [];
+        $buildPaths = [];
 
         if (false !== $config['output_path']) {
             $factories['_default'] = $this->entrypointFactory($container, '_default', $config['output_path'], $config['cache'], $config['strict_mode']);
             $cacheKeys['_default'] = $config['output_path'].'/'.self::ENTRYPOINTS_FILE_NAME;
+            $buildPaths['_default'] = $config['output_path'];
 
             $container->getDefinition('webpack_encore.entrypoint_lookup_collection')
                 ->setArgument(1, '_default');
@@ -47,6 +49,7 @@ final class WebpackEncoreExtension extends Extension
         foreach ($config['builds'] as $name => $path) {
             $factories[$name] = $this->entrypointFactory($container, $name, $path, $config['cache'], $config['strict_mode']);
             $cacheKeys[rawurlencode($name)] = $path.'/'.self::ENTRYPOINTS_FILE_NAME;
+            $buildPaths[$name] = $path;
         }
 
         $container->getDefinition('webpack_encore.exception_listener')
@@ -60,6 +63,9 @@ final class WebpackEncoreExtension extends Extension
         if (false !== $config['output_path']) {
             $container->setAlias(EntrypointLookupInterface::class, new Alias($this->getEntrypointServiceId('_default')));
         }
+
+        $container->getDefinition('webpack_encore.build_file_locator')
+            ->replaceArgument(0, $buildPaths);
 
         $defaultAttributes = [];
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -28,6 +28,7 @@
                     <argument type="collection">
                         <argument key="webpack_encore.entrypoint_lookup_collection" type="service" id="webpack_encore.entrypoint_lookup_collection" />
                         <argument key="webpack_encore.tag_renderer" type="service" id="webpack_encore.tag_renderer" />
+                        <argument key="webpack_encore.build_file_locator" type="service" id="webpack_encore.build_file_locator" />
                     </argument>
                 </service>
             </argument>
@@ -59,6 +60,10 @@
         <service id="webpack_encore.preload_assets_event_listener" class="Symfony\WebpackEncoreBundle\EventListener\PreLoadAssetsEventListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="webpack_encore.tag_renderer" />
+        </service>
+
+        <service id="webpack_encore.build_file_locator" class="Symfony\WebpackEncoreBundle\Asset\BuildFileLocator">
+            <argument /> <!-- build paths -->
         </service>
     </services>
 </container>

--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -10,6 +10,7 @@
 namespace Symfony\WebpackEncoreBundle\Twig;
 
 use Psr\Container\ContainerInterface;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
 use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
 use Twig\Extension\AbstractExtension;
@@ -31,6 +32,8 @@ final class EntryFilesTwigExtension extends AbstractExtension
             new TwigFunction('encore_entry_css_files', [$this, 'getWebpackCssFiles']),
             new TwigFunction('encore_entry_script_tags', [$this, 'renderWebpackScriptTags'], ['is_safe' => ['html']]),
             new TwigFunction('encore_entry_link_tags', [$this, 'renderWebpackLinkTags'], ['is_safe' => ['html']]),
+            new TwigFunction('encore_disable_file_tracking', [$this, 'disableReturnedFileTracking']),
+            new TwigFunction('encore_enable_file_tracking', [$this, 'enableReturnedFileTracking']),
         ];
     }
 
@@ -56,6 +59,27 @@ final class EntryFilesTwigExtension extends AbstractExtension
     {
         return $this->getTagRenderer()
             ->renderWebpackLinkTags($entryName, $packageName, $entrypointName);
+    }
+
+    public function disableReturnedFileTracking(string $entrypointName = '_default')
+    {
+        $this->changeReturnedFileTracking(false, $entrypointName);
+    }
+
+    public function enableReturnedFileTracking(string $entrypointName = '_default')
+    {
+        $this->changeReturnedFileTracking(true, $entrypointName);
+    }
+
+    private function changeReturnedFileTracking(bool $isEnabled, string $entrypointName)
+    {
+        $lookup = $this->getEntrypointLookup($entrypointName);
+
+        if (!$lookup instanceof EntrypointLookup) {
+            throw new \LogicException('In order to use encore_disable_returned_file_tracking/encore_enable_returned_file_tracking, the EntrypointLookupInterface must be an instance of EntrypointLookup.');
+        }
+
+        $lookup->enableReturnedFileTracking($isEnabled);
     }
 
     private function getEntrypointLookup(string $entrypointName): EntrypointLookupInterface

--- a/tests/Asset/BuildFileLocatorTest.php
+++ b/tests/Asset/BuildFileLocatorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Tests\Asset;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\WebpackEncoreBundle\Asset\BuildFileLocator;
+
+class BuildFileLocatorTest extends TestCase
+{
+    /**
+     * @dataProvider getFindFileTests
+     */
+    public function testFindFile(string $buildPath, string $assetPath, string $expectedPath)
+    {
+        $fileLocator = new BuildFileLocator(['_default' => $buildPath]);
+        $fileLocator->disableFileExistsCheck();
+
+        $this->assertSame($expectedPath, $fileLocator->findFile($assetPath));
+    }
+
+    public function getFindFileTests()
+    {
+        yield 'no_overlap' => [
+            '/app/public',
+            'foo.js',
+            '/app/public/foo.js'
+        ];
+
+        yield 'simple_overlap' => [
+            '/app/public/build',
+            'build/foo.js',
+            '/app/public/build/foo.js'
+        ];
+
+        yield 'simple_overlap_with_slash' => [
+            '/app/public/build',
+            '/build/foo.js',
+            '/app/public/build/foo.js'
+        ];
+
+        yield 'simple_overlap_with_build_path_slash' => [
+            '/app/public/build/',
+            'build/foo.js',
+            '/app/public/build/foo.js'
+        ];
+
+        yield 'partial_overlap' => [
+            '/app/public/build',
+            'build/subdirectory/foo.js',
+            '/app/public/build/subdirectory/foo.js'
+        ];
+
+        yield 'overlap_in_wrong_spot' => [
+            '/app/public/build',
+            'subdirectory/build/foo.js',
+            '/app/public/build/subdirectory/build/foo.js'
+        ];
+
+        yield 'windows_paths' => [
+            'C:\\\\app\\public\\build',
+            'build/foo.js',
+            'C:\\\\app\\public\\build/build/foo.js'
+        ];
+    }
+
+    // test only CSS & JS allowed
+}

--- a/tests/Asset/EntrypointLookupTest.php
+++ b/tests/Asset/EntrypointLookupTest.php
@@ -96,7 +96,7 @@ EOF;
         $this->assertEquals(
             ['file1.js', 'file3.js'],
             $this->entrypointLookup->getJavaScriptFiles('other_entry'),
-            'file1.js is returned even though it was also returned above',
+            'file1.js is returned even though it was also returned above'
         );
 
         $this->assertEquals(

--- a/tests/Asset/EntrypointLookupTest.php
+++ b/tests/Asset/EntrypointLookupTest.php
@@ -87,6 +87,33 @@ EOF;
         );
     }
 
+    public function testGetJavaScriptFilesWithFileTrackingDisabled()
+    {
+        // with file tracking on, grab a few files
+        $this->entrypointLookup->getJavaScriptFiles('my_entry');
+
+        $this->entrypointLookup->enableReturnedFileTracking(false);
+        $this->assertEquals(
+            ['file1.js', 'file3.js'],
+            $this->entrypointLookup->getJavaScriptFiles('other_entry'),
+            'file1.js is returned even though it was also returned above',
+        );
+
+        $this->assertEquals(
+            // file1.js is returned even though it was also returned above
+            ['file1.js', 'file3.js'],
+            $this->entrypointLookup->getJavaScriptFiles('other_entry'),
+            'repeat calls always return all the files'
+        );
+
+        $this->entrypointLookup->enableReturnedFileTracking(true);
+        $this->assertEquals(
+            ['file3.js'],
+            $this->entrypointLookup->getJavaScriptFiles('other_entry'),
+            'file1.js is not returned once tracking is re-enabled'
+        );
+    }
+
     public function testGetCssFiles()
     {
         $this->assertEquals(

--- a/tests/EventListener/ExceptionListenerTest.php
+++ b/tests/EventListener/ExceptionListenerTest.php
@@ -10,6 +10,7 @@
 namespace Symfony\WebpackEncoreBundle\Tests\EventListener;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use PHPUnit\Framework\TestCase;
@@ -39,7 +40,8 @@ class ExceptionListenerTest extends TestCase
 
         $request = new Request();
         $exception = new \Exception();
-        $event = new GetResponseForExceptionEvent(
+        $exceptionClass = class_exists(ExceptionEvent::class) ? ExceptionEvent::class : GetResponseForExceptionEvent::class;
+        $event = new $exceptionClass(
             $this->createMock(HttpKernelInterface::class),
             $request,
             HttpKernelInterface::MASTER_REQUEST,

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -29,6 +29,7 @@ use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
 use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
 use Symfony\WebpackEncoreBundle\CacheWarmer\EntrypointCacheWarmer;
 use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+use Twig\Extra\TwigExtraBundle\TwigExtraBundle;
 
 class IntegrationTest extends TestCase
 {
@@ -82,6 +83,33 @@ class IntegrationTest extends TestCase
             $html,
             // 1 time for my_entry, again for other_entry
             2
+        );
+    }
+
+    public function testTwigIntegrationWithSourceFiles()
+    {
+        $kernel = new WebpackEncoreIntegrationTestKernel(true);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $html = $container->get('twig')->render('@integration_test/inline_css_template.twig');
+
+        $this->assertStringContainsString(
+            '<h1 style="font-size: 20px;">Hello</h1>',
+            $html
+        );
+        $this->assertStringContainsString(
+            '<h2 style="color: purple;">World!</h2>',
+            $html
+        );
+
+        $this->assertStringContainsString(
+            "alert('Hello file1 JavaScript!')",
+            $html
+        );
+        $this->assertStringContainsString(
+            "alert('Hello file2 JavaScript!')",
+            $html
         );
     }
 
@@ -234,6 +262,7 @@ abstract class AbstractWebpackEncoreIntegrationTestKernel extends Kernel
             new FrameworkBundle(),
             new TwigBundle(),
             new WebpackEncoreBundle(),
+            new TwigExtraBundle(),
         ];
     }
 

--- a/tests/fixtures/build/file1.js
+++ b/tests/fixtures/build/file1.js
@@ -1,0 +1,1 @@
+alert('Hello file1 JavaScript!');

--- a/tests/fixtures/build/file2.js
+++ b/tests/fixtures/build/file2.js
@@ -1,0 +1,1 @@
+alert('Hello file2 JavaScript!');

--- a/tests/fixtures/build/styles.css
+++ b/tests/fixtures/build/styles.css
@@ -1,0 +1,3 @@
+h1 {
+    font-size: 20px;
+}

--- a/tests/fixtures/build/styles2.css
+++ b/tests/fixtures/build/styles2.css
@@ -1,0 +1,3 @@
+h2 {
+    color: purple;
+}

--- a/tests/fixtures/inline_css_template.twig
+++ b/tests/fixtures/inline_css_template.twig
@@ -1,0 +1,12 @@
+{# should not affect encore_entry_css_source() below  #}
+{{ encore_entry_link_tags('my_entry') }}
+{{ encore_entry_script_tags('my_entry') }}
+
+{% apply inline_css(encore_entry_css_source('my_entry')) %}
+<h1>Hello</h1>
+<h2>World!</h2>
+{% endapply %}
+
+<script>
+    {{ encore_entry_js_source('my_entry')|raw }}
+</script>

--- a/tests/fixtures/template_disable_tracking.twig
+++ b/tests/fixtures/template_disable_tracking.twig
@@ -1,0 +1,6 @@
+{% do encore_disable_file_tracking() %}
+{{ encore_entry_script_tags('my_entry') }}
+{{ encore_entry_link_tags('my_entry') }}
+{{ encore_entry_script_tags('other_entry') }}
+{{ encore_entry_link_tags('other_entry') }}
+{% do encore_enable_file_tracking() %}


### PR DESCRIPTION
Hi!

Fixes #90 

This contains several new features to help integration primarily with Mailer:

## encore_disable_file_tracking()
```twig
{% do encore_disable_file_tracking() %}
    {{ encore_entry_link_tags('entry1') }}
    {{ encore_entry_script_tags('entry1') }}
{% do encore_enable_file_tracking() %}
```

This is for usage in Email or PDF templates to tell encore to "not" use its "file tracking" system temporarily. This avoids issues where, for example, if you rendered 2 emails at once, the 2nd would have no link tags because Encore things they are already rendered.

I also considered an alternative syntax - just having `{% encore_encore_file_tracking %}` one time at the top of the template. If people really like that, we can try that.

## 2) encore_entry_css_source()

This file has "tracking" automatically disabled.

```twig
{% apply inline_css(encore_entry_css_source('my_entry')) %}
    <div>
        Hi! The CSS from my_entry will be converted into
        inline styles on any HTML elements inside.
    </div>
{% endapply %}
```

I'd appreciate any feedback! Thanks!

Note to self: will simplify https://symfonycasts.com/screencast/mailer/pdf-styles and https://symfonycasts.com/screencast/mailer/encore-inline_css