### PR TITLE
Adding support for custom attributes on rendered script and link tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
           env: deps=low
         - php: 7.4
           env: SYMFONY_PHPUNIT_VERSION=9.4
-        - php: nightly
+        - php: 8.0
           env: SYMFONY_PHPUNIT_VERSION=9.4
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ webpack_encore:
     output_path: '%kernel.project_dir%/public/build'
     # If multiple builds are defined (as shown below), you can disable the default build:
     # output_path: false
+
+    # Set attributes that will be rendered on all script and link tags
+    # script_attributes:
+    #     defer: true
+    #     referrerpolicy: origin
+    # link_attributes:
+    #     referrerpolicy: origin
     
     # if using Encore.enableIntegrityHashes() and need the crossorigin attribute (default: false, or use 'anonymous' or 'use-credentials')
     # crossorigin: 'anonymous'
@@ -84,6 +91,13 @@ For example, to render all of the `script` and `link` tags for a specific
     {{ parent() }}
 
     {{ encore_entry_script_tags('entry1') }}
+
+    {# or render a custom attribute #}
+    {#
+    {{ encore_entry_script_tags('entry1', attributes={
+        defer: true
+    }) }}
+    #}
 {% endblock %}
 
 {% block stylesheets %}
@@ -144,3 +158,44 @@ class SomeController
 If you have multiple builds, you can also autowire
 `Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollectionInterface`
 and use it to get the `EntrypointLookupInterface` object for any build.
+
+## Custom Attributes on script and link Tags
+
+Custom attributes can be added to rendered `script` or `link` in 3
+different ways:
+
+1. Via global config (`script_attributes` and `link_attributes`) - see the
+   config example above.
+
+1. When rendering in Twig - see the `attributes` option in the docs above.
+
+1. By listening to the `Symfony\WebpackEncoreBundle\Event\RenderAssetTagEvent`
+   event. For example:
+
+```php
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\WebpackEncoreBundle\Event\RenderAssetTagEvent;
+
+class ScriptNonceSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            RenderAssetTagEvent::class => 'onRenderAssetTag'
+        ];
+    }
+
+    public function onRenderAssetTag(RenderAssetTagEvent $event)
+    {
+        if ($event->isScriptTag()) {
+            $event->setAttribute('nonce', 'lookup nonce');
+        }
+    }
+}
+```
+
+Ok, have fun!

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,17 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=7.1.3",
-        "symfony/asset": "^3.4 || ^4.0 || ^5.0",
-        "symfony/config": "^3.4 || ^4.0 || ^5.0",
-        "symfony/dependency-injection": "^3.4 || ^4.0 || ^5.0",
-        "symfony/http-kernel": "^3.4 || ^4.0 || ^5.0",
+        "symfony/asset": "^4.4 || ^5.0",
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
         "symfony/service-contracts": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^4.3.5 || ^5.0",
-        "symfony/twig-bundle": "^3.4 || ^4.0 || ^5.0",
-        "symfony/web-link": "^3.4 || ^4.0 || ^5.0"
+        "symfony/framework-bundle": "^4.4 || ^5.0",
+        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/twig-bundle": "^4.4 || ^5.0",
+        "symfony/web-link": "^4.4 || ^5.0"
     },
     "extra": {
         "thanks": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -55,7 +55,7 @@ final class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->normalizeKeys(false)
                     ->scalarPrototype()
-                    ->validate()
+                        ->validate()
                         ->always(function ($values) {
                             if (isset($values['_default'])) {
                                 throw new InvalidDefinitionException("Key '_default' can't be used as build name.");
@@ -63,7 +63,22 @@ final class Configuration implements ConfigurationInterface
 
                             return $values;
                         })
+                        ->end()
                     ->end()
+                ->end()
+                ->arrayNode('script_attributes')
+                    ->info('Key/value pair of attributes to render on all script tags')
+                    ->example('{ defer: true, referrerpolicy: "origin" }')
+                    ->useAttributeAsKey('name')
+                    ->normalizeKeys(false)
+                    ->scalarPrototype()->end()
+                ->end()
+                ->arrayNode('link_attributes')
+                    ->info('Key/value pair of attributes to render on all CSS link tags')
+                    ->example('{ referrerpolicy: "origin" }')
+                    ->useAttributeAsKey('name')
+                    ->normalizeKeys(false)
+                    ->scalarPrototype()->end()
                 ->end()
             ->end()
         ;

--- a/src/DependencyInjection/WebpackEncoreExtension.php
+++ b/src/DependencyInjection/WebpackEncoreExtension.php
@@ -68,7 +68,9 @@ final class WebpackEncoreExtension extends Extension
         }
 
         $container->getDefinition('webpack_encore.tag_renderer')
-            ->replaceArgument(2, $defaultAttributes);
+            ->replaceArgument(2, $defaultAttributes)
+            ->replaceArgument(3, $config['script_attributes'])
+            ->replaceArgument(4, $config['link_attributes']);
 
         if ($config['preload']) {
             if (!class_exists(AddLinkHeaderListener::class)) {

--- a/src/Event/RenderAssetTagEvent.php
+++ b/src/Event/RenderAssetTagEvent.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Event;
+
+/**
+ * Dispatched each time a script or link tag is rendered.
+ */
+final class RenderAssetTagEvent
+{
+    public const TYPE_SCRIPT = 'script';
+    public const TYPE_LINK = 'link';
+
+    private $type;
+    private $url;
+    private $attributes;
+
+    public function __construct(string $type, string $url, array $attributes)
+    {
+        $this->type = $type;
+        $this->url = $url;
+        $this->attributes = $attributes;
+    }
+
+    public function isScriptTag(): bool
+    {
+        return $this->type === self::TYPE_SCRIPT;
+    }
+
+    public function isLinkTag(): bool
+    {
+        return $this->type === self::TYPE_LINK;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @param string $name The attribute name
+     * @param string|bool $value Value can be "true" to have an attribute without a value (e.g. "defer")
+     */
+    public function setAttribute(string $name, $value): void
+    {
+        $this->attributes[$name] = $value;
+    }
+
+    public function removeAttribute(string $name): void
+    {
+        unset($this->attributes[$name]);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -17,7 +17,10 @@
             <tag name="kernel.reset" method="reset" />
             <argument type="service" id="webpack_encore.entrypoint_lookup_collection" />
             <argument type="service" id="assets.packages" />
-            <argument type="collection" />
+            <argument type="collection"/> <!-- Default attributes-->
+            <argument type="collection"/> <!-- Default script attributes -->
+            <argument type="collection"/> <!-- Default link attributes -->
+            <argument type="service" id="event_dispatcher" />
         </service>
 
         <service id="webpack_encore.twig_entry_files_extension" class="Symfony\WebpackEncoreBundle\Twig\EntryFilesTwigExtension">

--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -46,16 +46,16 @@ final class EntryFilesTwigExtension extends AbstractExtension
             ->getCssFiles($entryName);
     }
 
-    public function renderWebpackScriptTags(string $entryName, string $packageName = null, string $entrypointName = '_default'): string
+    public function renderWebpackScriptTags(string $entryName, string $packageName = null, string $entrypointName = '_default', array $attributes = []): string
     {
         return $this->getTagRenderer()
-            ->renderWebpackScriptTags($entryName, $packageName, $entrypointName);
+            ->renderWebpackScriptTags($entryName, $packageName, $entrypointName, $attributes);
     }
 
-    public function renderWebpackLinkTags(string $entryName, string $packageName = null, string $entrypointName = '_default'): string
+    public function renderWebpackLinkTags(string $entryName, string $packageName = null, string $entrypointName = '_default', array $attributes = []): string
     {
         return $this->getTagRenderer()
-            ->renderWebpackLinkTags($entryName, $packageName, $entrypointName);
+            ->renderWebpackLinkTags($entryName, $packageName, $entrypointName, $attributes);
     }
 
     private function getEntrypointLookup(string $entrypointName): EntrypointLookupInterface

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -11,9 +11,11 @@ namespace Symfony\WebpackEncoreBundle\Tests\Asset;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollection;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
 use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
+use Symfony\WebpackEncoreBundle\Event\RenderAssetTagEvent;
 use Symfony\WebpackEncoreBundle\Tests\TestEntrypointLookupIntegrityDataProviderInterface;
 
 class TagRendererTest extends TestCase
@@ -40,15 +42,79 @@ class TagRendererTest extends TestCase
             ->willReturnCallback(function ($path) {
                 return 'http://localhost:8080'.$path;
             });
-        $renderer = new TagRenderer($entrypointCollection, $packages, []);
+        $renderer = new TagRenderer($entrypointCollection, $packages, ['defer' => true]);
 
         $output = $renderer->renderWebpackScriptTags('my_entry', 'custom_package');
         $this->assertStringContainsString(
-            '<script src="http://localhost:8080/build/file1.js"></script>',
+            '<script src="http://localhost:8080/build/file1.js" defer></script>',
             $output
         );
         $this->assertStringContainsString(
-            '<script src="http://localhost:8080/build/file2.js"></script>',
+            '<script src="http://localhost:8080/build/file2.js" defer></script>',
+            $output
+        );
+    }
+
+    public function testRenderScriptTagsWithExtraAttributes()
+    {
+        $entrypointLookup = $this->createMock(EntrypointLookupInterface::class);
+        $entrypointLookup->expects($this->once())
+            ->method('getJavaScriptFiles')
+            ->willReturn(['/build/file1.js']);
+        $entrypointCollection = $this->createMock(EntrypointLookupCollection::class);
+        $entrypointCollection->expects($this->once())
+            ->method('getEntrypointLookup')
+            ->willReturn($entrypointLookup);
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->exactly(1))
+            ->method('getUrl')
+            ->willReturn('http://localhost:8080/build/file1.js');
+        $renderer = new TagRenderer($entrypointCollection, $packages, [
+            'defer' => true,
+            'nonce' => 'abc123'
+        ], ['referrerpolicy' => 'origin']);
+
+        $output = $renderer->renderWebpackScriptTags('my_entry', null, null, [
+            // override the attribute
+            'nonce' => '12345',
+        ]);
+        $this->assertStringContainsString(
+            '<script src="http://localhost:8080/build/file1.js" defer nonce="12345" referrerpolicy="origin"></script>',
+            $output
+        );
+    }
+
+    public function testRenderScriptTagsDispatchesAnEvent()
+    {
+        $entrypointLookup = $this->createMock(EntrypointLookupInterface::class);
+        $entrypointLookup->expects($this->once())
+            ->method('getJavaScriptFiles')
+            ->willReturn(['/build/file1.js']);
+        $entrypointCollection = $this->createMock(EntrypointLookupCollection::class);
+        $entrypointCollection->expects($this->once())
+            ->method('getEntrypointLookup')
+            ->willReturn($entrypointLookup);
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->exactly(1))
+            ->method('getUrl')
+            ->willReturn('http://localhost:8080/build/file1.js');
+
+        $event = new RenderAssetTagEvent(RenderAssetTagEvent::TYPE_SCRIPT, 'http://foo', [
+            'src' => 'http://localhost:8080/build/file1.js',
+            'nonce' => 'some_nonce_here',
+        ]);
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher->expects($this->once())
+            ->method('dispatch')
+            ->willReturn($event);
+
+        $renderer = new TagRenderer($entrypointCollection, $packages, [], [], [], $dispatcher);
+
+        $output = $renderer->renderWebpackScriptTags('my_entry');
+        $this->assertStringContainsString(
+            '<script src="http://localhost:8080/build/file1.js" nonce="some_nonce_here"></script>',
             $output
         );
     }
@@ -75,7 +141,7 @@ class TagRendererTest extends TestCase
 
         $output = $renderer->renderWebpackScriptTags('my_entry', 'custom_package');
         $this->assertStringContainsString(
-            '<script crossorigin="anonymous" src="http://localhost:8080/build/file&lt;&quot;bad_chars.js"></script>',
+            '<script src="http://localhost:8080/build/file&lt;&quot;bad_chars.js" crossorigin="anonymous"></script>',
             $output
         );
     }
@@ -121,17 +187,17 @@ class TagRendererTest extends TestCase
 
         $output = $renderer->renderWebpackScriptTags('my_entry', 'custom_package');
         $this->assertStringContainsString(
-            '<script crossorigin="anonymous" src="http://localhost:8080/build/file1.js"></script>',
+            '<script src="http://localhost:8080/build/file1.js" crossorigin="anonymous"></script>',
             $output
         );
         $output = $renderer->renderWebpackScriptTags('my_entry', null, 'second');
         $this->assertStringContainsString(
-            '<script crossorigin="anonymous" src="http://localhost:8080/build/file2.js"></script>',
+            '<script src="http://localhost:8080/build/file2.js" crossorigin="anonymous"></script>',
             $output
         );
         $output = $renderer->renderWebpackScriptTags('my_entry', 'specific_package', 'third');
         $this->assertStringContainsString(
-            '<script crossorigin="anonymous" src="http://localhost:8080/build/file3.js"></script>',
+            '<script src="http://localhost:8080/build/file3.js" crossorigin="anonymous"></script>',
             $output
         );
     }
@@ -168,11 +234,11 @@ class TagRendererTest extends TestCase
 
         $output = $renderer->renderWebpackScriptTags('my_entry', 'custom_package');
         $this->assertStringContainsString(
-            '<script crossorigin="anonymous" src="http://localhost:8080/build/file1.js" integrity="sha384-Q86c+opr0lBUPWN28BLJFqmLhho+9ZcJpXHorQvX6mYDWJ24RQcdDarXFQYN8HLc"></script>',
+            '<script src="http://localhost:8080/build/file1.js" crossorigin="anonymous" integrity="sha384-Q86c+opr0lBUPWN28BLJFqmLhho+9ZcJpXHorQvX6mYDWJ24RQcdDarXFQYN8HLc"></script>',
             $output
         );
         $this->assertStringContainsString(
-            '<script crossorigin="anonymous" src="http://localhost:8080/build/file2.js" integrity="sha384-ymG7OyjISWrOpH9jsGvajKMDEOP/mKJq8bHC0XdjQA6P8sg2nu+2RLQxcNNwE/3J"></script>',
+            '<script src="http://localhost:8080/build/file2.js" crossorigin="anonymous" integrity="sha384-ymG7OyjISWrOpH9jsGvajKMDEOP/mKJq8bHC0XdjQA6P8sg2nu+2RLQxcNNwE/3J"></script>',
             $output
         );
     }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -35,12 +35,13 @@ class IntegrationTest extends TestCase
     public function testTwigIntegration()
     {
         $kernel = new WebpackEncoreIntegrationTestKernel(true);
+        $kernel->scriptAttributes = ['referrerpolicy' => 'origin'];
         $kernel->boot();
         $twig = $this->getTwigEnvironmentFromBootedKernel($kernel);
 
         $html1 = $twig->render('@integration_test/template.twig');
         $this->assertStringContainsString(
-            '<script src="/build/file1.js" integrity="sha384-Q86c+opr0lBUPWN28BLJFqmLhho+9ZcJpXHorQvX6mYDWJ24RQcdDarXFQYN8HLc"></script>',
+            '<script src="/build/file1.js" referrerpolicy="origin" defer integrity="sha384-Q86c+opr0lBUPWN28BLJFqmLhho+9ZcJpXHorQvX6mYDWJ24RQcdDarXFQYN8HLc"></script>',
             $html1
         );
         $this->assertStringContainsString(
@@ -49,7 +50,7 @@ class IntegrationTest extends TestCase
             $html1
         );
         $this->assertStringContainsString(
-            '<script src="/build/other3.js"></script>',
+            '<script src="/build/other3.js" referrerpolicy="origin"></script>',
             $html1
         );
         $this->assertStringContainsString(
@@ -118,7 +119,7 @@ class IntegrationTest extends TestCase
     public function testEnabledStrictMode_throwsException_ifBuildMissing()
     {
         $this->expectException(\Twig\Error\RuntimeError::class);
-        $this->expectExceptionMessageRegExp('/Could not find the entrypoints file/');
+        $this->expectExceptionMessage('Could not find the entrypoints file from Webpack: the file "missing_build/entrypoints.json" does not exist.');
 
         $kernel = new WebpackEncoreIntegrationTestKernel(true);
         $kernel->outputPath = 'missing_build';
@@ -208,6 +209,7 @@ abstract class AbstractWebpackEncoreIntegrationTestKernel extends Kernel
     public $builds = [
         'different_build' => __DIR__.'/fixtures/different_build',
     ];
+    public $scriptAttributes = [];
 
     public function __construct(bool $enableAssets)
     {
@@ -255,6 +257,7 @@ abstract class AbstractWebpackEncoreIntegrationTestKernel extends Kernel
             'preload' => true,
             'builds' => $this->builds,
             'strict_mode' => $this->strictMode,
+            'script_attributes' => $this->scriptAttributes,
         ]);
 
         $container->register(WebpackEncoreCacheWarmerTester::class)

--- a/tests/fixtures/template.twig
+++ b/tests/fixtures/template.twig
@@ -1,4 +1,6 @@
-{{ encore_entry_script_tags('my_entry') }}
+{{ encore_entry_script_tags('my_entry', attributes={
+    defer: true
+}) }}
 {{ encore_entry_link_tags('my_entry') }}
 {{ encore_entry_script_tags('third_entry', null, 'different_build') }}
 {{ encore_entry_link_tags('third_entry', null, 'different_build') }}


### PR DESCRIPTION
Fixes #10 - thanks to @dsech for the idea of relying on named Twig arguments (otherwise the new Twig attributes argument is the 4th argument... and rather inconvenient).

This can be configured in *3* different ways:

## 1) Globally

```
webpack_encore:
    # ...
    script_attributes:
        defer: true
```

2) when when using the Twig functions:

```twig
{{ encore_entry_script_tags('my_entry', attributes={
    defer: true
}) }}
```

3) Via a new `RenderAssetTagEvent`

As stated at the bottom of #10 - https://github.com/symfony/webpack-encore-bundle/issues/10#issuecomment-756835238 - there may be some additional options that would also be nice, but this probably covers the biggest use-case.

NOTE: This also drops support for EOL Symfony versions.

Cheers!