### PR TITLE
Allow custom EntrypointLookupCollection when instantiating the TagRenderer

### DIFF
--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -45,10 +45,10 @@ class TagRenderer implements ResetInterface
                     return $entrypointLookupCollection;
                 }])
             );
-        } elseif ($entrypointLookupCollection instanceof EntrypointLookupCollection) {
+        } elseif ($entrypointLookupCollection instanceof EntrypointLookupCollectionInterface) {
             $this->entrypointLookupCollection = $entrypointLookupCollection;
         } else {
-            throw new \TypeError('The "$entrypointLookupCollection" argument must be an instance of EntrypointLookupCollection.');
+            throw new \TypeError('The "$entrypointLookupCollection" argument must be an instance of EntrypointLookupCollectionInterface.');
         }
 
         $this->packages = $packages;


### PR DESCRIPTION
Hi 👋

There is an interface "EntrypointLookupCollectionInterface" but I wonder why the TagRender is not making use of it?

I want to override the TagRenderer to work with another EntrypointLookupCollection, so I defined my own service:

```yaml
    app.tag_renderer:
        class: Symfony\WebpackEncoreBundle\Asset\TagRenderer
        arguments:
            - '@app.entrypoint_lookup_collection'
            - '@assets.packages'
            - []
            - []
            - []
            - '@event_dispatcher'
        tags:
            - { name: 'kernel.reset', method: 'reset'}
```