### PR TITLE
Fix the safety of the stimulus_controller function

### DIFF
--- a/src/Twig/StimulusTwigExtension.php
+++ b/src/Twig/StimulusTwigExtension.php
@@ -18,7 +18,7 @@ final class StimulusTwigExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('stimulus_controller', [$this, 'renderStimulusController'], ['needs_environment' => true, 'is_safe' => ['all']]),
+            new TwigFunction('stimulus_controller', [$this, 'renderStimulusController'], ['needs_environment' => true, 'is_safe' => ['html_attr']]),
         ];
     }
 


### PR DESCRIPTION
This function is safe in an html_attr context (and so automatically in the html context thanks to the way Twig treats html as a subset of html_attr). But the implementation does not ensure safety in other contexts.