### PR TITLE
Fixing null and false attributes 

### DIFF
--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -177,12 +177,18 @@ class TagRenderer implements ResetInterface
 
     private function convertArrayToAttributes(array $attributesMap): string
     {
+        // remove attributes set specifically to false
+        $attributesMap = array_filter($attributesMap, function($value) {
+            return $value !== false;
+        });
+
         return implode(' ', array_map(
             function ($key, $value) {
                 // allows for things like defer: true to only render "defer"
-                if ($value === true) {
+                if ($value === true || $value === null) {
                     return $key;
                 }
+
                 return sprintf('%s="%s"', $key, htmlentities($value));
             },
             array_keys($attributesMap),

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -85,6 +85,35 @@ class TagRendererTest extends TestCase
         );
     }
 
+    public function testRenderScriptTagsWithFalseyAttributes()
+    {
+        $entrypointLookup = $this->createMock(EntrypointLookupInterface::class);
+        $entrypointLookup->expects($this->once())
+            ->method('getJavaScriptFiles')
+            ->willReturn(['/build/file1.js']);
+        $entrypointCollection = $this->createMock(EntrypointLookupCollection::class);
+        $entrypointCollection->expects($this->once())
+            ->method('getEntrypointLookup')
+            ->willReturn($entrypointLookup);
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->once())
+            ->method('getUrl')
+            ->willReturnCallback(function ($path) {
+                return 'http://localhost:8080' . $path;
+            });
+        $renderer = new TagRenderer($entrypointCollection, $packages, [
+            'defer' => false, // false disables the attribute
+            'async' => null, // null allows the attribute
+        ]);
+
+        $output = $renderer->renderWebpackScriptTags('my_entry');
+        $this->assertStringContainsString(
+            '<script src="http://localhost:8080/build/file1.js" async></script>',
+            $output
+        );
+    }
+
     public function testRenderScriptTagsDispatchesAnEvent()
     {
         $entrypointLookup = $this->createMock(EntrypointLookupInterface::class);


### PR DESCRIPTION
Hi!

Suppose this config:

```yaml
webpack_encore:
    script_attributes:
        defer: false
        async: null
```

This PR changes what this outputs:

```html
<!-- before -->
<script src="..." defer="" async=""></script>

<!-- after -->
<script src="..." async></script>
```

This was an oversight when I built the feature.

With this PR, `false` correctly means "do not show this attribute". `null` is a bit trickier: I chose to make this mean "show the attribute, but with value (e.g. `<script defer>`). Any other values are rendered normally.

Cheers!