### PR TITLE
Remove fallback cache on cache warmer

### DIFF
--- a/src/CacheWarmer/EntrypointCacheWarmer.php
+++ b/src/CacheWarmer/EntrypointCacheWarmer.php
@@ -9,7 +9,6 @@
 
 namespace Symfony\WebpackEncoreBundle\CacheWarmer;
 
-use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\AbstractPhpFileCacheWarmer;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
@@ -19,10 +18,10 @@ class EntrypointCacheWarmer extends AbstractPhpFileCacheWarmer
 {
     private $cacheKeys;
 
-    public function __construct(array $cacheKeys, string $phpArrayFile, CacheItemPoolInterface $fallbackPool)
+    public function __construct(array $cacheKeys, string $phpArrayFile)
     {
         $this->cacheKeys = $cacheKeys;
-        parent::__construct($phpArrayFile, $fallbackPool);
+        parent::__construct($phpArrayFile);
     }
 
     /**

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -44,7 +44,6 @@
             <tag name="kernel.cache_warmer" />
             <argument /> <!-- build list of entrypoint paths -->
             <argument>%kernel.cache_dir%/webpack_encore.cache.php</argument>
-            <argument type="service" id="cache.webpack_encore" />
         </service>
 
         <service id="webpack_encore.cache" class="Symfony\Component\Cache\Adapter\PhpArrayAdapter">


### PR DESCRIPTION
Since Symfony 4.2 fallback cache on cache warmer is not supported anymore.

Here's the PR that dropped it: https://github.com/symfony/symfony/pull/28331