### PR TITLE
Add return type-hints to twig extensions

### DIFF
--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -24,7 +24,7 @@ final class EntryFilesTwigExtension extends AbstractExtension
         $this->container = $container;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('encore_entry_js_files', [$this, 'getWebpackJsFiles']),

--- a/src/Twig/StimulusTwigExtension.php
+++ b/src/Twig/StimulusTwigExtension.php
@@ -15,7 +15,7 @@ use Twig\TwigFunction;
 
 final class StimulusTwigExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('stimulus_controller', [$this, 'renderStimulusController'], ['needs_environment' => true, 'is_safe' => ['html_attr']]),


### PR DESCRIPTION
This should not be a BC break as classes are marked as final