### PR TITLE
Add .editorconfig to help with normal style errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
From https://github.com/symfony/webpack-encore-bundle/pull/139#discussion_r675920927

Either we merge this (which I obviously think we should) or we remove .github/.editorconfig 