### PR TITLE
Fix the "lowest" CI job

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "symfony/framework-bundle": "^4.4 || ^5.0",
-        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/phpunit-bridge": "^5.3",
         "symfony/twig-bundle": "^4.4 || ^5.0",
         "symfony/web-link": "^4.4 || ^5.0"
     },


### PR DESCRIPTION
We dont need to make sure we are compatible with `symfony/phpunit-bridge:4.4`