### PR TITLE
Skipping null values from rendering

### DIFF
--- a/src/Twig/StimulusTwigExtension.php
+++ b/src/Twig/StimulusTwigExtension.php
@@ -57,6 +57,10 @@ final class StimulusTwigExtension extends AbstractExtension
             $controllers[] = $controllerName;
 
             foreach ($controllerValues as $key => $value) {
+                if (null === $value) {
+                    continue;
+                }
+
                 if (!is_scalar($value)) {
                     $value = json_encode($value);
                 }


### PR DESCRIPTION
Hi there!

This should fix a weird situation when we are rendering stringified `null` value attribute and stimulus using `null` string as a value instead of just skipping it.