### PR TITLE
Increase version constraint of symfony/service-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/config": "^4.4 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
         "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",
-        "symfony/service-contracts": "^1.0 || ^2.0"
+        "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",


### PR DESCRIPTION
This allows to install `symfony/webpack-encore-bundle` in a new Symfony 6 project without it being necessary to downgrade `psr/container` and `symfony/service-contracts`

Fixes #155 