### PR TITLE
Fix missing integrity hash on preload

### DIFF
--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -28,6 +28,7 @@ class TagRenderer implements ResetInterface
     private $eventDispatcher;
 
     private $renderedFiles = [];
+    private $renderedFilesWithAttributes = [];
 
     public function __construct(
         $entrypointLookupCollection,
@@ -60,7 +61,7 @@ class TagRenderer implements ResetInterface
         $this->reset();
     }
 
-    public function renderWebpackScriptTags(string $entryName, string $packageName = null, string $entrypointName = null, array $extraAttributes = []): string
+    public function renderWebpackScriptTags(string $entryName, string $packageName = null, string $entrypointName = null, array $extraAttributes = [], bool $includeAttributes = false): string
     {
         $entrypointName = $entrypointName ?: '_default';
         $scriptTags = [];
@@ -91,13 +92,14 @@ class TagRenderer implements ResetInterface
                 $this->convertArrayToAttributes($attributes)
             );
 
-            $this->renderedFiles['scripts'][] = $attributes;
+            $this->renderedFiles['scripts'][] = $attributes["src"];
+            $this->renderedFilesWithAttributes['scripts'][] = $attributes;
         }
 
         return implode('', $scriptTags);
     }
 
-    public function renderWebpackLinkTags(string $entryName, string $packageName = null, string $entrypointName = null, array $extraAttributes = []): string
+    public function renderWebpackLinkTags(string $entryName, string $packageName = null, string $entrypointName = null, array $extraAttributes = [], bool $includeAttributes = false): string
     {
         $entrypointName = $entrypointName ?: '_default';
         $scriptTags = [];
@@ -129,7 +131,8 @@ class TagRenderer implements ResetInterface
                 $this->convertArrayToAttributes($attributes)
             );
 
-            $this->renderedFiles['styles'][] = $attributes;
+            $this->renderedFiles['styles'][] = $attributes["href"];
+            $this->renderedFilesWithAttributes['styles'][] = $attributes;
         }
 
         return implode('', $scriptTags);
@@ -145,6 +148,16 @@ class TagRenderer implements ResetInterface
         return $this->renderedFiles['styles'];
     }
 
+    public function getRenderedScriptsWithAttributes(): array
+    {
+        return $this->renderedFilesWithAttributes['scripts'];
+    }
+
+    public function getRenderedStylesWithAttributes(): array
+    {
+        return $this->renderedFilesWithAttributes['styles'];
+    }
+
     public function getDefaultAttributes(): array
     {
         return $this->defaultAttributes;
@@ -152,7 +165,7 @@ class TagRenderer implements ResetInterface
 
     public function reset()
     {
-        $this->renderedFiles = [
+        $this->renderedFiles = $this->renderedFilesWithAttributes = [
             'scripts' => [],
             'styles' => [],
         ];

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -91,7 +91,7 @@ class TagRenderer implements ResetInterface
                 $this->convertArrayToAttributes($attributes)
             );
 
-            $this->renderedFiles['scripts'][] = $attributes['src'];
+            $this->renderedFiles['scripts'][] = $attributes;
         }
 
         return implode('', $scriptTags);
@@ -129,7 +129,7 @@ class TagRenderer implements ResetInterface
                 $this->convertArrayToAttributes($attributes)
             );
 
-            $this->renderedFiles['styles'][] = $attributes['href'];
+            $this->renderedFiles['styles'][] = $attributes;
         }
 
         return implode('', $scriptTags);

--- a/src/EventListener/PreLoadAssetsEventListener.php
+++ b/src/EventListener/PreLoadAssetsEventListener.php
@@ -53,21 +53,31 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         $defaultAttributes = $this->tagRenderer->getDefaultAttributes();
         $crossOrigin = $defaultAttributes['crossorigin'] ?? false;
 
-        foreach ($this->tagRenderer->getRenderedScripts() as $href) {
-            $link = ($this->createLink('preload', $href))->withAttribute('as', 'script');
+        foreach ($this->tagRenderer->getRenderedScripts() as $attributes) {
+            $attributes = array_merge($defaultAttributes, $attributes);
 
-            if (false !== $crossOrigin) {
-                $link = $link->withAttribute('crossorigin', $crossOrigin);
+            $link = ($this->createLink('preload', $attributes["src"]))->withAttribute('as', 'script');
+
+            if (!empty($attributes['crossorigin']) && false !== $attributes['crossorigin']) {
+                $link = $link->withAttribute('crossorigin', $attributes['crossorigin']);
+            }
+            if (!empty($attributes['integrity'])) {
+                $link = $link->withAttribute('integrity', $attributes['integrity']);
             }
 
             $linkProvider = $linkProvider->withLink($link);
         }
 
-        foreach ($this->tagRenderer->getRenderedStyles() as $href) {
-            $link = ($this->createLink('preload', $href))->withAttribute('as', 'style');
+        foreach ($this->tagRenderer->getRenderedStyles() as $attributes) {
+            $attributes = array_merge($defaultAttributes, $attributes);
 
-            if (false !== $crossOrigin) {
-                $link = $link->withAttribute('crossorigin', $crossOrigin);
+            $link = ($this->createLink('preload', $attributes["href"]))->withAttribute('as', 'style');
+
+            if (!empty($attributes['crossorigin']) && false !== $attributes['crossorigin']) {
+                $link = $link->withAttribute('crossorigin', $attributes['crossorigin']);
+            }
+            if (!empty($attributes['integrity'])) {
+                $link = $link->withAttribute('integrity', $attributes['integrity']);
             }
 
             $linkProvider = $linkProvider->withLink($link);

--- a/src/EventListener/PreLoadAssetsEventListener.php
+++ b/src/EventListener/PreLoadAssetsEventListener.php
@@ -53,7 +53,7 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         $defaultAttributes = $this->tagRenderer->getDefaultAttributes();
         $crossOrigin = $defaultAttributes['crossorigin'] ?? false;
 
-        foreach ($this->tagRenderer->getRenderedScripts() as $attributes) {
+        foreach ($this->tagRenderer->getRenderedScriptsWithAttributes() as $attributes) {
             $attributes = array_merge($defaultAttributes, $attributes);
 
             $link = ($this->createLink('preload', $attributes['src']))->withAttribute('as', 'script');
@@ -68,7 +68,7 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
             $linkProvider = $linkProvider->withLink($link);
         }
 
-        foreach ($this->tagRenderer->getRenderedStyles() as $attributes) {
+        foreach ($this->tagRenderer->getRenderedStylesWithAttributes() as $attributes) {
             $attributes = array_merge($defaultAttributes, $attributes);
 
             $link = ($this->createLink('preload', $attributes['href']))->withAttribute('as', 'style');

--- a/src/EventListener/PreLoadAssetsEventListener.php
+++ b/src/EventListener/PreLoadAssetsEventListener.php
@@ -56,7 +56,7 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         foreach ($this->tagRenderer->getRenderedScripts() as $attributes) {
             $attributes = array_merge($defaultAttributes, $attributes);
 
-            $link = ($this->createLink('preload', $attributes["src"]))->withAttribute('as', 'script');
+            $link = ($this->createLink('preload', $attributes['src']))->withAttribute('as', 'script');
 
             if (!empty($attributes['crossorigin']) && false !== $attributes['crossorigin']) {
                 $link = $link->withAttribute('crossorigin', $attributes['crossorigin']);
@@ -71,7 +71,7 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         foreach ($this->tagRenderer->getRenderedStyles() as $attributes) {
             $attributes = array_merge($defaultAttributes, $attributes);
 
-            $link = ($this->createLink('preload', $attributes["href"]))->withAttribute('as', 'style');
+            $link = ($this->createLink('preload', $attributes['href']))->withAttribute('as', 'style');
 
             if (!empty($attributes['crossorigin']) && false !== $attributes['crossorigin']) {
                 $link = $link->withAttribute('crossorigin', $attributes['crossorigin']);

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -296,6 +296,9 @@ class TagRendererTest extends TestCase
 
         $renderer->renderWebpackScriptTags('my_entry');
         $renderer->renderWebpackLinkTags('my_entry');
+        $this->assertSame(['http://localhost:8080/build/file1.js', 'http://localhost:8080/build/file2.js'], $renderer->getRenderedScripts());
+        $this->assertSame(['http://localhost:8080/build/file1.css'], $renderer->getRenderedStyles());
+
         $this->assertSame([
             [
                 'src' => 'http://localhost:8080/build/file1.js',
@@ -303,16 +306,19 @@ class TagRendererTest extends TestCase
             [
                 'src' => 'http://localhost:8080/build/file2.js',
             ],
-        ], $renderer->getRenderedScripts());
+        ], $renderer->getRenderedScriptsWithAttributes());
         $this->assertSame([
             [
                 'rel' => 'stylesheet',
                 'href' => 'http://localhost:8080/build/file1.css',
             ],
-        ], $renderer->getRenderedStyles());
+        ], $renderer->getRenderedStylesWithAttributes());
+
 
         $renderer->reset();
         $this->assertEmpty($renderer->getRenderedScripts());
         $this->assertEmpty($renderer->getRenderedStyles());
+        $this->assertEmpty($renderer->getRenderedScriptsWithAttributes());
+        $this->assertEmpty($renderer->getRenderedStylesWithAttributes());
     }
 }

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -296,8 +296,20 @@ class TagRendererTest extends TestCase
 
         $renderer->renderWebpackScriptTags('my_entry');
         $renderer->renderWebpackLinkTags('my_entry');
-        $this->assertSame(['http://localhost:8080/build/file1.js', 'http://localhost:8080/build/file2.js'], $renderer->getRenderedScripts());
-        $this->assertSame(['http://localhost:8080/build/file1.css'], $renderer->getRenderedStyles());
+        $this->assertSame([
+            [
+                'src' => 'http://localhost:8080/build/file1.js',
+            ],
+            [
+                'src' => 'http://localhost:8080/build/file2.js',
+            ],
+        ], $renderer->getRenderedScripts());
+        $this->assertSame([
+            [
+                'rel' => 'stylesheet',
+                'href' => 'http://localhost:8080/build/file1.css',
+            ],
+        ], $renderer->getRenderedStyles());
 
         $renderer->reset();
         $this->assertEmpty($renderer->getRenderedScripts());

--- a/tests/EventListener/PreLoadAssetsEventListenerTest.php
+++ b/tests/EventListener/PreLoadAssetsEventListenerTest.php
@@ -28,8 +28,17 @@ class PreLoadAssetsEventListenerTest extends TestCase
     {
         $tagRenderer = $this->createMock(TagRenderer::class);
         $tagRenderer->expects($this->once())->method('getDefaultAttributes')->willReturn(['crossorigin' => 'anonymous']);
-        $tagRenderer->expects($this->once())->method('getRenderedScripts')->willReturn(['/file1.js']);
-        $tagRenderer->expects($this->once())->method('getRenderedStyles')->willReturn(['/css/file1.css']);
+        $tagRenderer->expects($this->once())->method('getRenderedScripts')->willReturn([
+            [
+                'src' => '/file1.js',
+            ],
+        ]);
+        $tagRenderer->expects($this->once())->method('getRenderedStyles')->willReturn([
+            [
+                'rel' => 'stylesheet',
+                'href' => '/css/file1.css',
+            ],
+        ]);
 
         $request = new Request();
         $response = new Response();
@@ -58,7 +67,11 @@ class PreLoadAssetsEventListenerTest extends TestCase
     {
         $tagRenderer = $this->createMock(TagRenderer::class);
         $tagRenderer->expects($this->once())->method('getDefaultAttributes')->willReturn(['crossorigin' => 'anonymous']);
-        $tagRenderer->expects($this->once())->method('getRenderedScripts')->willReturn(['/file1.js']);
+        $tagRenderer->expects($this->once())->method('getRenderedScripts')->willReturn([
+            [
+                'src' => '/file1.js',
+            ],
+        ]);
         $tagRenderer->expects($this->once())->method('getRenderedStyles')->willReturn([]);
 
         $request = new Request();


### PR DESCRIPTION
Has mentioned in issue #101 , integrity hash is missing into the link headers.