### PR TITLE
Add `entryExists` to EntrypointLookupInterface

### DIFF
--- a/src/Asset/EntrypointLookupInterface.php
+++ b/src/Asset/EntrypointLookupInterface.php
@@ -28,4 +28,6 @@ interface EntrypointLookupInterface extends ResetInterface
      * Resets the state of this service.
      */
     public function reset();
+
+    public function entryExists(string $entryName): bool;
 }

--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -62,12 +62,8 @@ final class EntryFilesTwigExtension extends AbstractExtension
 
     public function entryExists(string $entryName, string $entrypointName = '_default'): bool
     {
-        $entrypointLookup = $this->getEntrypointLookup($entrypointName);
-        if (!$entrypointLookup instanceof EntrypointLookup) {
-            throw new \LogicException(sprintf('Cannot use entryExists() unless the entrypoint lookup is an instance of "%s"', EntrypointLookup::class));
-        }
-
-        return $entrypointLookup->entryExists($entryName);
+        return $this->getEntrypointLookup($entrypointName)
+            ->entryExists($entryName);
     }
 
     private function getEntrypointLookup(string $entrypointName): EntrypointLookupInterface

--- a/src/Twig/EntryFilesTwigExtension.php
+++ b/src/Twig/EntryFilesTwigExtension.php
@@ -10,7 +10,6 @@
 namespace Symfony\WebpackEncoreBundle\Twig;
 
 use Psr\Container\ContainerInterface;
-use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
 use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
 use Twig\Extension\AbstractExtension;


### PR DESCRIPTION
I don't know why it was proposed in [#147](https://github.com/symfony/webpack-encore-bundle/pull/147#discussion_r803759695) _not_ to include `entryExists` in `EntrypointLookupInterface`, but it doesn't makes sense to test agains't a specific class instead of the interface.

In my case, this cause an issue as I cannot use dependence injection on `EntrypointLookupInterface` and expect `entryExists` to be present. 

If this is not approved, I suggest adding `entryExists` to it's own interface and have `EntrypointLookup` implement both (although you won't fix the dependency injection problem).