### PR TITLE
Do not JSON encode stringable values

### DIFF
--- a/src/Twig/StimulusTwigExtension.php
+++ b/src/Twig/StimulusTwigExtension.php
@@ -61,11 +61,11 @@ final class StimulusTwigExtension extends AbstractExtension
                     continue;
                 }
 
-                if (!is_scalar($value)) {
+                if ($value instanceof \Stringable || (\is_object($value) && \is_callable([$value, '__toString']))) {
+                    $value = (string) $value;
+                } elseif (!\is_scalar($value)) {
                     $value = json_encode($value);
-                }
-
-                if (\is_bool($value)) {
+                } elseif (\is_bool($value)) {
                     $value = $value ? 'true' : 'false';
                 }
 


### PR DESCRIPTION
When using `stimulus_controller` with values generated by twig, the values are converted to JSON. Which prevent the following code working out of the box.

```twig
{% set tooltip %}
  Hello <strong>{{ name }}</strong>
{% endset %}

<div {{ stimulus_controller('tooltip', {html: true, title: tooltip}) }}>
  title
</div>
```

Because the content of the variable tooltip is an `\Twig\Markup` object.

This PR stringifies `values` instead of json_encoding.