### PR TITLE
Fixing reset assets trigger on sub-requests

### DIFF
--- a/src/EventListener/ResetAssetsEventListener.php
+++ b/src/EventListener/ResetAssetsEventListener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Symfony\WebpackEncoreBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollection;
 
@@ -33,8 +34,14 @@ class ResetAssetsEventListener implements EventSubscriberInterface
         ];
     }
 
-    public function resetAssets()
+    public function resetAssets(FinishRequestEvent $event)
     {
+        // Handle deprecated `KernelEvent::isMasterRequest() - Can be removed when Symfony < 5.3 support is dropped.
+        $mainRequestMethod = method_exists($event, 'isMainRequest') ? 'isMainRequest' : 'isMasterRequest';
+
+        if (!$event->$mainRequestMethod()) {
+            return;
+        }
         foreach ($this->buildNames as $name) {
             $this->entrypointLookupCollection->getEntrypointLookup($name)->reset();
         }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -114,13 +114,13 @@ class IntegrationTest extends TestCase
         $html = $response->getContent();
 
         $containsCount0 = substr_count($html, '<script src="/build/file1.js"');
-        $this->assertSame(2, $containsCount0);
+        $this->assertSame(1, $containsCount0);
 
         $containsCount1 = substr_count($html, '<link rel="stylesheet" href="/build/styles3.css"');
-        $this->assertSame(2, $containsCount1);
+        $this->assertSame(1, $containsCount1);
 
         $containsCount2 = substr_count($html, '<link rel="stylesheet" href="/build/styles4.css"');
-        $this->assertSame(2, $containsCount2);
+        $this->assertSame(1, $containsCount2);
     }
 
     public function testCacheWarmer()


### PR DESCRIPTION
`1.14.0` is broken when a page contains sub requests, all the files managed by the package run twice. The event `KernelEvents::FINISH_REQUEST` should be handled for MainRequest only.

Sadly we are stuck at 1.13.2 until it's fixed