### PR TITLE
Log instead of throw when manifest.json is missing

### DIFF
--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -127,11 +127,11 @@ class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProvid
         $this->entriesData = json_decode(file_get_contents($this->entrypointJsonPath), true);
 
         if (null === $this->entriesData) {
-            throw new \InvalidArgumentException(sprintf('There was a problem JSON decoding the "%s" file', $this->entrypointJsonPath));
+            throw new \InvalidArgumentException(sprintf('There was a problem JSON decoding the "%s" file.', $this->entrypointJsonPath));
         }
 
         if (!isset($this->entriesData['entrypoints'])) {
-            throw new \InvalidArgumentException(sprintf('Could not find an "entrypoints" key in the "%s" file', $this->entrypointJsonPath));
+            throw new \InvalidArgumentException(sprintf('Could not find an "entrypoints" key in the "%s" file.', $this->entrypointJsonPath));
         }
 
         if ($this->cache) {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -34,6 +34,7 @@
                     </argument>
                 </service>
             </argument>
+            <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
         <service id="webpack_encore.twig_stimulus_extension" class="Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension">


### PR DESCRIPTION
Now that webapp-pack [contains webpack-encore-bundle](https://github.com/symfony/webapp-pack/blob/main/composer.json#L31), extending [`base.html.twig`](https://github.com/symfony/recipes/blob/main/symfony/twig-bundle/5.4/templates/base.html.twig) throws an exception unless one runs `yarn` beforehand.

This is bad DX for newcomers. Instead, I propose to log a warning. It's not like empty apps have any mandatory JS :)