### PR TITLE
Add Stimulus Twig filters, handle action parameters & allow filters/functions to return array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,6 @@ jobs:
 
       - name: Run tests
         env:
-          SYMFONY_DEPRECATIONS_HELPER: "max[self]=0"
+          SYMFONY_DEPRECATIONS_HELPER: "max[self]=11"
           SYMFONY_PHPUNIT_VERSION: "8.5"
         run: ./vendor/bin/simple-phpunit

--- a/README.md
+++ b/README.md
@@ -229,16 +229,18 @@ Any non-scalar values (like `data: [1, 2, 3, 4]`) are JSON-encoded. And all
 values are properly escaped (the string `&#x5B;` is an escaped
 `[` character, so the attribute is really `[1,2,3,4]`).
 
-If you have multiple controllers on the same element, pass them all as an
-associative array in the first argument:
+If you have multiple controllers on the same element, you can chain them as there's also a `stimulus_controller` filter:
 
 ```twig
-<div {{ stimulus_controller({
-    'chart': { 'name': 'Likes' },
-    'other-controller': { },
-) }}>
+<div {{ stimulus_controller('chart', { 'name': 'Likes' })|stimulus_controller('other-controller') }}>
     Hello
 </div>
+```
+
+You can also retrieve the generated attributes as an array, which can be helpful e.g. for forms:
+
+```twig
+{{ form_start(form, { attr: stimulus_controller('chart', { 'name': 'Likes' }).toArray() }) }}
 ```
 
 ### stimulus_action
@@ -256,21 +258,33 @@ For example:
 <div data-action="click->controller#method">Hello</div>
 ```
 
-If you have multiple actions and/or methods on the same element, pass them all as an
-associative array in the first argument:
+If you have multiple actions and/or methods on the same element, you can chain them as there's also a
+`stimulus_action` filter:
 
 ```twig
-<div {{ stimulus_action({
- 'controller': 'method',
- 'other-controller': ['method', {'resize@window': 'onWindowResize'}]
-}) }}>
+<div {{ stimulus_action('controller', 'method')|stimulus_action('other-controller', 'test') }}>
     Hello
 </div>
 
 <!-- would render -->
-<div data-action="controller#method other-controller#method resize@window->other-controller#onWindowResize">
+<div data-action="controller#method other-controller#test">
     Hello
 </div>
+```
+
+You can also retrieve the generated attributes as an array, which can be helpful e.g. for forms:
+
+```twig
+{{ form_row(form.password, { attr: stimulus_action('hello-controller', 'checkPasswordStrength').toArray() }) }}
+```
+
+You can also pass [parameters](https://stimulus.hotwired.dev/reference/actions#action-parameters) to actions:
+
+```twig
+<div {{ stimulus_action('hello-controller', 'method', 'click', { 'count': 3 }) }}>Hello</div>
+
+<!-- would render -->
+<div data-action="click->hello-controller#method" data-hello-controller-count-param="3">Hello</div>
 ```
 
 ### stimulus_target
@@ -288,14 +302,10 @@ For example:
 <div data-controller-target="a-target second-target">Hello</div>
 ```
 
-If you have multiple targets on the same element, pass them all as an
-associative array in the first argument:
+If you have multiple targets on the same element, you can chain them as there's also a `stimulus_target` filter:
 
 ```twig
-<div {{ stimulus_target({
- 'controller': 'a-target',
- 'other-controller': 'another-target'
-}) }}>
+<div {{ stimulus_target('controller', 'a-target')|stimulus_target('other-controller', 'another-target') }}>
     Hello
 </div>
 
@@ -303,6 +313,12 @@ associative array in the first argument:
 <div data-controller-target="a-target" data-other-controller-target="another-target">
     Hello
 </div>
+```
+
+You can also retrieve the generated attributes as an array, which can be helpful e.g. for forms:
+
+```twig
+{{ form_row(form.password, { attr: stimulus_target('hello-controller', 'a-target').toArray() }) }}
 ```
 
 Ok, have fun!

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         "symfony/asset": "^4.4 || ^5.0 || ^6.0",
         "symfony/config": "^4.4 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",
+        "symfony/polyfill-php80": "^1.25.0",
         "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -57,6 +57,6 @@ parameters:
 
 		-
 			message: "#^Function twig_escape_filter not found\\.$#"
-			count: 7
-			path: src/Twig/StimulusTwigExtension.php
+			count: 1
+			path: src/Dto/AbstractStimulusDto.php
 

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -30,15 +30,9 @@
       <code>Link|FigLink</code>
     </UndefinedDocblockClass>
   </file>
-  <file src="src/Twig/StimulusTwigExtension.php">
-    <UndefinedFunction occurrences="7">
-      <code>twig_escape_filter($env, $actionName, 'html_attr')</code>
-      <code>twig_escape_filter($env, $targetNames, 'html_attr')</code>
-      <code>twig_escape_filter($env, $this-&gt;normalizeControllerName($controllerName), 'html_attr')</code>
-      <code>twig_escape_filter($env, $this-&gt;normalizeControllerName($controllerName), 'html_attr')</code>
-      <code>twig_escape_filter($env, $this-&gt;normalizeControllerName($controllerName), 'html_attr')</code>
-      <code>twig_escape_filter($env, $this-&gt;normalizeKeyName($key), 'html_attr')</code>
-      <code>twig_escape_filter($env, $value, 'html_attr')</code>
+  <file src="src/Dto/AbstractStimulusDto.php">
+    <UndefinedFunction occurrences="1">
+      <code>twig_escape_filter($this->env, $value, 'html_attr')</code>
     </UndefinedFunction>
   </file>
 </files>

--- a/src/Dto/AbstractStimulusDto.php
+++ b/src/Dto/AbstractStimulusDto.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Dto;
+
+use Twig\Environment;
+
+/**
+ * @internal
+ */
+abstract class AbstractStimulusDto implements \Stringable
+{
+    /**
+     * @var Environment
+     */
+    private $env;
+
+    public function __construct(Environment $env)
+    {
+        $this->env = $env;
+    }
+
+    abstract public function toArray(): array;
+
+    protected function getFormattedControllerName(string $controllerName): string
+    {
+        return $this->escapeAsHtmlAttr($this->normalizeControllerName($controllerName));
+    }
+
+    protected function getFormattedValue($value)
+    {
+        if ($value instanceof \Stringable || (\is_object($value) && \is_callable([$value, '__toString']))) {
+            $value = (string) $value;
+        } elseif (!is_scalar($value)) {
+            $value = json_encode($value);
+        } elseif (\is_bool($value)) {
+            $value = $value ? 'true' : 'false';
+        }
+
+        return $this->escapeAsHtmlAttr($value);
+    }
+
+    protected function escapeAsHtmlAttr($value): string
+    {
+        return (string) twig_escape_filter($this->env, $value, 'html_attr');
+    }
+
+    /**
+     * Normalize a Stimulus controller name into its HTML equivalent (no special character and / becomes --).
+     *
+     * @see https://stimulus.hotwired.dev/reference/controllers
+     */
+    private function normalizeControllerName(string $controllerName): string
+    {
+        return preg_replace('/^@/', '', str_replace('_', '-', str_replace('/', '--', $controllerName)));
+    }
+}

--- a/src/Dto/StimulusActionsDto.php
+++ b/src/Dto/StimulusActionsDto.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Dto;
+
+final class StimulusActionsDto extends AbstractStimulusDto
+{
+    private $actions = [];
+    private $parameters = [];
+
+    /**
+     * @param string|array $dataOrControllerName This can either be a map of controller names
+     *                                           as keys set to their "actions" and "events".
+     *                                           Or this can be a string controller name and
+     *                                           action and event are passed as the 2nd and 3rd arguments.
+     * @param string|null  $actionName           The action to trigger if a string is passed to the 1st argument. Optional.
+     * @param string|null  $eventName            The event to listen to trigger if a string is passed to the 1st argument. Optional.
+     * @param array        $parameters           Parameters to pass to the action if a string is passed to the 1st argument. Optional.
+     *
+     * @throws \Twig\Error\RuntimeError
+     */
+    public function addAction($dataOrControllerName, string $actionName = null, string $eventName = null, array $parameters = []): void
+    {
+        if (\is_string($dataOrControllerName)) {
+            $data = [$dataOrControllerName => null === $eventName ? [[$actionName]] : [[$eventName => $actionName]]];
+        } else {
+            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_action() is deprecated.');
+            if ($actionName || $eventName || $parameters) {
+                throw new \InvalidArgumentException('You cannot pass a string to the second or third argument nor an array to the fourth argument while passing an array to the first argument of stimulus_action(): check the documentation.');
+            }
+
+            $data = $dataOrControllerName;
+
+            if (!$data) {
+                return;
+            }
+        }
+
+        foreach ($data as $controllerName => $controllerActions) {
+            $controllerName = $this->getFormattedControllerName($controllerName);
+
+            if (\is_string($controllerActions)) {
+                $controllerActions = [[$controllerActions]];
+            }
+
+            foreach ($controllerActions as $possibleEventName => $controllerAction) {
+                if (\is_string($possibleEventName) && \is_string($controllerAction)) {
+                    $controllerAction = [$possibleEventName => $controllerAction];
+                } elseif (\is_string($controllerAction)) {
+                    $controllerAction = [$controllerAction];
+                }
+
+                foreach ($controllerAction as $eventName => $actionName) {
+                    $action = $controllerName.'#'.$this->escapeAsHtmlAttr($actionName);
+
+                    if (\is_string($eventName)) {
+                        $action = $eventName.'->'.$action;
+                    }
+
+                    $this->actions[] = $action;
+                }
+            }
+
+            foreach ($parameters as $name => $value) {
+                $this->parameters['data-'.$controllerName.'-'.$name.'-param'] = $this->getFormattedValue($value);
+            }
+        }
+    }
+
+    public function __toString(): string
+    {
+        if (0 === \count($this->actions)) {
+            return '';
+        }
+
+        return rtrim('data-action="'.implode(' ', $this->actions).'" '.implode(' ', array_map(static function (string $attribute, string $value): string {
+            return $attribute.'="'.$value.'"';
+        }, array_keys($this->parameters), $this->parameters)));
+    }
+
+    public function toArray(): array
+    {
+        return ['data-action' => implode(' ', $this->actions)] + $this->parameters;
+    }
+}

--- a/src/Dto/StimulusControllersDto.php
+++ b/src/Dto/StimulusControllersDto.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Dto;
+
+final class StimulusControllersDto extends AbstractStimulusDto
+{
+    private $controllers = [];
+    private $values = [];
+
+    /**
+     * @param string|array $dataOrControllerName This can either be a map of controller names
+     *                                           as keys set to their "values". Or this
+     *                                           can be a string controller name and data
+     *                                           is passed as the 2nd argument.
+     * @param array        $controllerValues     array of data if a string is passed to the 1st argument
+     *
+     * @throws \Twig\Error\RuntimeError
+     */
+    public function addController($dataOrControllerName, array $controllerValues = []): void
+    {
+        if (\is_string($dataOrControllerName)) {
+            $data = [$dataOrControllerName => $controllerValues];
+        } else {
+            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_controller() is deprecated.');
+            if ($controllerValues) {
+                throw new \InvalidArgumentException('You cannot pass an array to the first and second argument of stimulus_controller(): check the documentation.');
+            }
+
+            $data = $dataOrControllerName;
+
+            if (!$data) {
+                return;
+            }
+        }
+
+        foreach ($data as $controllerName => $controllerValues) {
+            $controllerName = $this->getFormattedControllerName($controllerName);
+            $this->controllers[] = $controllerName;
+
+            foreach ($controllerValues as $key => $value) {
+                if (null === $value) {
+                    continue;
+                }
+
+                $key = $this->escapeAsHtmlAttr($this->normalizeKeyName($key));
+                $value = $this->getFormattedValue($value);
+
+                $this->values['data-'.$controllerName.'-'.$key.'-value'] = $value;
+            }
+        }
+    }
+
+    public function __toString(): string
+    {
+        if (0 === \count($this->controllers)) {
+            return '';
+        }
+
+        return rtrim('data-controller="'.implode(' ', $this->controllers).'" '.implode(' ', array_map(static function (string $attribute, string $value): string {
+            return $attribute.'="'.$value.'"';
+        }, array_keys($this->values), $this->values)));
+    }
+
+    public function toArray(): array
+    {
+        if (0 === \count($this->controllers)) {
+            return [];
+        }
+
+        return [
+            'data-controller' => implode(' ', $this->controllers),
+        ] + $this->values;
+    }
+
+    /**
+     * Normalize a Stimulus Value API key into its HTML equivalent ("kebab case").
+     * Backport features from symfony/string.
+     *
+     * @see https://stimulus.hotwired.dev/reference/values
+     */
+    private function normalizeKeyName(string $str): string
+    {
+        // Adapted from ByteString::camel
+        $str = ucfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $str))));
+
+        // Adapted from ByteString::snake
+        return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1-\2', $str));
+    }
+}

--- a/src/Dto/StimulusTargetsDto.php
+++ b/src/Dto/StimulusTargetsDto.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Dto;
+
+final class StimulusTargetsDto extends AbstractStimulusDto
+{
+    private $targets = [];
+
+    /**
+     * @param string|array $dataOrControllerName This can either be a map of controller names
+     *                                           as keys set to their "targets". Or this can
+     *                                           be a string controller name and targets are
+     *                                           passed as the 2nd argument.
+     * @param string|null  $targetNames          The space-separated list of target names if a string is passed to the 1st argument. Optional.
+     *
+     * @throws \Twig\Error\RuntimeError
+     */
+    public function addTarget($dataOrControllerName, string $targetNames = null): void
+    {
+        if (\is_string($dataOrControllerName)) {
+            $data = [$dataOrControllerName => $targetNames];
+        } else {
+            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_target() is deprecated.');
+            if ($targetNames) {
+                throw new \InvalidArgumentException('You cannot pass a string to the second argument while passing an array to the first argument of stimulus_target(): check the documentation.');
+            }
+
+            $data = $dataOrControllerName;
+
+            if (!$data) {
+                return;
+            }
+        }
+
+        foreach ($data as $controllerName => $targetNames) {
+            $controllerName = $this->getFormattedControllerName($controllerName);
+
+            $this->targets['data-'.$controllerName.'-target'] = $this->escapeAsHtmlAttr($targetNames);
+        }
+    }
+
+    public function __toString(): string
+    {
+        if (0 === \count($this->targets)) {
+            return '';
+        }
+
+        return implode(' ', array_map(static function (string $attribute, string $value): string {
+            return $attribute.'="'.$value.'"';
+        }, array_keys($this->targets), $this->targets));
+    }
+
+    public function toArray(): array
+    {
+        return $this->targets;
+    }
+}

--- a/src/Twig/StimulusTwigExtension.php
+++ b/src/Twig/StimulusTwigExtension.php
@@ -9,8 +9,12 @@
 
 namespace Symfony\WebpackEncoreBundle\Twig;
 
+use Symfony\WebpackEncoreBundle\Dto\StimulusActionsDto;
+use Symfony\WebpackEncoreBundle\Dto\StimulusControllersDto;
+use Symfony\WebpackEncoreBundle\Dto\StimulusTargetsDto;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 final class StimulusTwigExtension extends AbstractExtension
@@ -24,6 +28,15 @@ final class StimulusTwigExtension extends AbstractExtension
         ];
     }
 
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('stimulus_controller', [$this, 'appendStimulusController'], ['is_safe' => ['html_attr']]),
+            new TwigFilter('stimulus_action', [$this, 'appendStimulusAction'], ['is_safe' => ['html_attr']]),
+            new TwigFilter('stimulus_target', [$this, 'appendStimulusTarget'], ['is_safe' => ['html_attr']]),
+        ];
+    }
+
     /**
      * @param string|array $dataOrControllerName This can either be a map of controller names
      *                                           as keys set to their "values". Or this
@@ -33,50 +46,28 @@ final class StimulusTwigExtension extends AbstractExtension
      *
      * @throws \Twig\Error\RuntimeError
      */
-    public function renderStimulusController(Environment $env, $dataOrControllerName, array $controllerValues = []): string
+    public function renderStimulusController(Environment $env, $dataOrControllerName, array $controllerValues = []): StimulusControllersDto
     {
-        if (\is_string($dataOrControllerName)) {
-            $data = [$dataOrControllerName => $controllerValues];
-        } else {
-            if ($controllerValues) {
-                throw new \InvalidArgumentException('You cannot pass an array to the first and second argument of stimulus_controller(): check the documentation.');
-            }
+        $dto = new StimulusControllersDto($env);
+        $dto->addController($dataOrControllerName, $controllerValues);
 
-            $data = $dataOrControllerName;
+        return $dto;
+    }
 
-            if (!$data) {
-                return '';
-            }
-        }
+    /**
+     * @param string|array $dataOrControllerName This can either be a map of controller names
+     *                                           as keys set to their "values". Or this
+     *                                           can be a string controller name and data
+     *                                           is passed as the 2nd argument.
+     * @param array        $controllerValues     array of data if a string is passed to the 1st argument
+     *
+     * @throws \Twig\Error\RuntimeError
+     */
+    public function appendStimulusController(StimulusControllersDto $dto, $dataOrControllerName, array $controllerValues = []): StimulusControllersDto
+    {
+        $dto->addController($dataOrControllerName, $controllerValues);
 
-        $controllers = [];
-        $values = [];
-
-        foreach ($data as $controllerName => $controllerValues) {
-            $controllerName = twig_escape_filter($env, $this->normalizeControllerName($controllerName), 'html_attr');
-            $controllers[] = $controllerName;
-
-            foreach ($controllerValues as $key => $value) {
-                if (null === $value) {
-                    continue;
-                }
-
-                if ($value instanceof \Stringable || (\is_object($value) && \is_callable([$value, '__toString']))) {
-                    $value = (string) $value;
-                } elseif (!\is_scalar($value)) {
-                    $value = json_encode($value);
-                } elseif (\is_bool($value)) {
-                    $value = $value ? 'true' : 'false';
-                }
-
-                $key = twig_escape_filter($env, $this->normalizeKeyName($key), 'html_attr');
-                $value = twig_escape_filter($env, $value, 'html_attr');
-
-                $values[] = 'data-'.$controllerName.'-'.$key.'-value="'.$value.'"';
-            }
-        }
-
-        return rtrim('data-controller="'.implode(' ', $controllers).'" '.implode(' ', $values));
+        return $dto;
     }
 
     /**
@@ -86,54 +77,34 @@ final class StimulusTwigExtension extends AbstractExtension
      *                                           action and event are passed as the 2nd and 3rd arguments.
      * @param string|null  $actionName           The action to trigger if a string is passed to the 1st argument. Optional.
      * @param string|null  $eventName            The event to listen to trigger if a string is passed to the 1st argument. Optional.
+     * @param array        $parameters           Parameters to pass to the action if a string is passed to the 1st argument. Optional.
      *
      * @throws \Twig\Error\RuntimeError
      */
-    public function renderStimulusAction(Environment $env, $dataOrControllerName, string $actionName = null, string $eventName = null): string
+    public function renderStimulusAction(Environment $env, $dataOrControllerName, string $actionName = null, string $eventName = null, array $parameters = []): StimulusActionsDto
     {
-        if (\is_string($dataOrControllerName)) {
-            $data = [$dataOrControllerName => null === $eventName ? [[$actionName]] : [[$eventName => $actionName]]];
-        } else {
-            if ($actionName || $eventName) {
-                throw new \InvalidArgumentException('You cannot pass a string to the second or third argument while passing an array to the first argument of stimulus_action(): check the documentation.');
-            }
+        $dto = new StimulusActionsDto($env);
+        $dto->addAction($dataOrControllerName, $actionName, $eventName, $parameters);
 
-            $data = $dataOrControllerName;
+        return $dto;
+    }
 
-            if (!$data) {
-                return '';
-            }
-        }
+    /**
+     * @param string|array $dataOrControllerName This can either be a map of controller names
+     *                                           as keys set to their "actions" and "events".
+     *                                           Or this can be a string controller name and
+     *                                           action and event are passed as the 2nd and 3rd arguments.
+     * @param string|null  $actionName           The action to trigger if a string is passed to the 1st argument. Optional.
+     * @param string|null  $eventName            The event to listen to trigger if a string is passed to the 1st argument. Optional.
+     * @param array        $parameters           Parameters to pass to the action if a string is passed to the 1st argument. Optional.
+     *
+     * @throws \Twig\Error\RuntimeError
+     */
+    public function appendStimulusAction(StimulusActionsDto $dto, $dataOrControllerName, string $actionName = null, string $eventName = null, array $parameters = []): StimulusActionsDto
+    {
+        $dto->addAction($dataOrControllerName, $actionName, $eventName, $parameters);
 
-        $actions = [];
-
-        foreach ($data as $controllerName => $controllerActions) {
-            $controllerName = twig_escape_filter($env, $this->normalizeControllerName($controllerName), 'html_attr');
-
-            if (\is_string($controllerActions)) {
-                $controllerActions = [[$controllerActions]];
-            }
-
-            foreach ($controllerActions as $possibleEventName => $controllerAction) {
-                if (\is_string($possibleEventName) && \is_string($controllerAction)) {
-                    $controllerAction = [$possibleEventName => $controllerAction];
-                } elseif (\is_string($controllerAction)) {
-                    $controllerAction = [$controllerAction];
-                }
-
-                foreach ($controllerAction as $eventName => $actionName) {
-                    $action = $controllerName.'#'.twig_escape_filter($env, $actionName, 'html_attr');
-
-                    if (\is_string($eventName)) {
-                        $action = $eventName.'->'.$action;
-                    }
-
-                    $actions[] = $action;
-                }
-            }
-        }
-
-        return 'data-action="'.implode(' ', $actions).'"';
+        return $dto;
     }
 
     /**
@@ -145,57 +116,27 @@ final class StimulusTwigExtension extends AbstractExtension
      *
      * @throws \Twig\Error\RuntimeError
      */
-    public function renderStimulusTarget(Environment $env, $dataOrControllerName, string $targetNames = null): string
+    public function renderStimulusTarget(Environment $env, $dataOrControllerName, string $targetNames = null): StimulusTargetsDto
     {
-        if (\is_string($dataOrControllerName)) {
-            $data = [$dataOrControllerName => $targetNames];
-        } else {
-            if ($targetNames) {
-                throw new \InvalidArgumentException('You cannot pass a string to the second argument while passing an array to the first argument of stimulus_target(): check the documentation.');
-            }
+        $dto = new StimulusTargetsDto($env);
+        $dto->addTarget($dataOrControllerName, $targetNames);
 
-            $data = $dataOrControllerName;
-
-            if (!$data) {
-                return '';
-            }
-        }
-
-        $targets = [];
-
-        foreach ($data as $controllerName => $targetNames) {
-            $controllerName = twig_escape_filter($env, $this->normalizeControllerName($controllerName), 'html_attr');
-
-            $targets['data-'.$controllerName.'-target'] = twig_escape_filter($env, $targetNames, 'html_attr');
-        }
-
-        return implode(' ', array_map(static function (string $attribute, string $value): string {
-            return $attribute.'="'.$value.'"';
-        }, array_keys($targets), $targets));
+        return $dto;
     }
 
     /**
-     * Normalize a Stimulus controller name into its HTML equivalent (no special character and / becomes --).
+     * @param string|array $dataOrControllerName This can either be a map of controller names
+     *                                           as keys set to their "targets". Or this can
+     *                                           be a string controller name and targets are
+     *                                           passed as the 2nd argument.
+     * @param string|null  $targetNames          The space-separated list of target names if a string is passed to the 1st argument. Optional.
      *
-     * @see https://stimulus.hotwired.dev/reference/controllers
+     * @throws \Twig\Error\RuntimeError
      */
-    private function normalizeControllerName(string $str): string
+    public function appendStimulusTarget(StimulusTargetsDto $dto, $dataOrControllerName, string $targetNames = null): StimulusTargetsDto
     {
-        return preg_replace('/^@/', '', str_replace('_', '-', str_replace('/', '--', $str)));
-    }
+        $dto->addTarget($dataOrControllerName, $targetNames);
 
-    /**
-     * Normalize a Stimulus Value API key into its HTML equivalent ("kebab case").
-     * Backport features from symfony/string.
-     *
-     * @see https://stimulus.hotwired.dev/reference/values
-     */
-    private function normalizeKeyName(string $str): string
-    {
-        // Adapted from ByteString::camel
-        $str = ucfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $str))));
-
-        // Adapted from ByteString::snake
-        return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1-\2', $str));
+        return $dto;
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -207,7 +207,8 @@ class IntegrationTest extends TestCase
         yield 'empty' => [
             'dataOrControllerName' => [],
             'controllerValues' => [],
-            'expected' => '',
+            'expectedString' => '',
+            'expectedArray' => [],
         ];
 
         yield 'single-controller-no-data' => [
@@ -215,7 +216,8 @@ class IntegrationTest extends TestCase
                 'my-controller' => [],
             ],
             'controllerValues' => [],
-            'expected' => 'data-controller="my-controller"',
+            'expectedString' => 'data-controller="my-controller"',
+            'expectedArray' => ['data-controller' => 'my-controller'],
         ];
 
         yield 'single-controller-scalar-data' => [
@@ -225,7 +227,8 @@ class IntegrationTest extends TestCase
                 ],
             ],
             'controllerValues' => [],
-            'expected' => 'data-controller="my-controller" data-my-controller-my-value-value="scalar-value"',
+            'expectedString' => 'data-controller="my-controller" data-my-controller-my-value-value="scalar-value"',
+            'expectedArray' => ['data-controller' => 'my-controller', 'data-my-controller-my-value-value' => 'scalar-value'],
         ];
 
         yield 'single-controller-typed-data' => [
@@ -237,7 +240,8 @@ class IntegrationTest extends TestCase
                 ],
             ],
             'controllerValues' => [],
-            'expected' => 'data-controller="my-controller" data-my-controller-boolean-value="true" data-my-controller-number-value="4" data-my-controller-string-value="str"',
+            'expectedString' => 'data-controller="my-controller" data-my-controller-boolean-value="true" data-my-controller-number-value="4" data-my-controller-string-value="str"',
+            'expectedArray' => ['data-controller' => 'my-controller', 'data-my-controller-boolean-value' => 'true', 'data-my-controller-number-value' => '4', 'data-my-controller-string-value' => 'str'],
         ];
 
         yield 'single-controller-nested-data' => [
@@ -247,7 +251,8 @@ class IntegrationTest extends TestCase
                 ],
             ],
             'controllerValues' => [],
-            'expected' => 'data-controller="my-controller" data-my-controller-my-value-value="&#x7B;&quot;nested&quot;&#x3A;&quot;array&quot;&#x7D;"',
+            'expectedString' => 'data-controller="my-controller" data-my-controller-my-value-value="&#x7B;&quot;nested&quot;&#x3A;&quot;array&quot;&#x7D;"',
+            'expectedArray' => ['data-controller' => 'my-controller', 'data-my-controller-my-value-value' => '&#x7B;&quot;nested&quot;&#x3A;&quot;array&quot;&#x7D;'],
         ];
 
         yield 'multiple-controllers-scalar-data' => [
@@ -260,7 +265,8 @@ class IntegrationTest extends TestCase
                 ],
             ],
             'controllerValues' => [],
-            'expected' => 'data-controller="my-controller another-controller" data-my-controller-my-value-value="scalar-value" data-another-controller-another-value-value="scalar-value&#x20;2"',
+            'expectedString' => 'data-controller="my-controller another-controller" data-my-controller-my-value-value="scalar-value" data-another-controller-another-value-value="scalar-value&#x20;2"',
+            'expectedArray' => ['data-controller' => 'my-controller another-controller', 'data-my-controller-my-value-value' => 'scalar-value', 'data-another-controller-another-value-value' => 'scalar-value&#x20;2'],
         ];
 
         yield 'normalize-names' => [
@@ -270,51 +276,73 @@ class IntegrationTest extends TestCase
                 ],
             ],
             'controllerValues' => [],
-            'expected' => 'data-controller="symfony--ux-dropzone--dropzone" data-symfony--ux-dropzone--dropzone-my-key-value="true"',
+            'expectedString' => 'data-controller="symfony--ux-dropzone--dropzone" data-symfony--ux-dropzone--dropzone-my-key-value="true"',
+            'expectedArray' => ['data-controller' => 'symfony--ux-dropzone--dropzone', 'data-symfony--ux-dropzone--dropzone-my-key-value' => 'true'],
         ];
 
         yield 'short-single-controller-no-data' => [
             'dataOrControllerName' => 'my-controller',
             'controllerValues' => [],
-            'expected' => 'data-controller="my-controller"',
+            'expectedString' => 'data-controller="my-controller"',
+            'expectedArray' => ['data-controller' => 'my-controller'],
         ];
 
         yield 'short-single-controller-with-data' => [
             'dataOrControllerName' => 'my-controller',
             'controllerValues' => ['myValue' => 'scalar-value'],
-            'expected' => 'data-controller="my-controller" data-my-controller-my-value-value="scalar-value"',
+            'expectedString' => 'data-controller="my-controller" data-my-controller-my-value-value="scalar-value"',
+            'expectedArray' => ['data-controller' => 'my-controller', 'data-my-controller-my-value-value' => 'scalar-value'],
         ];
 
         yield 'false-attribute-value-renders-false' => [
             'dataOrControllerName' => 'false-controller',
             'controllerValues' => ['isEnabled' => false],
-            'expected' => 'data-controller="false-controller" data-false-controller-is-enabled-value="false"',
+            'expectedString' => 'data-controller="false-controller" data-false-controller-is-enabled-value="false"',
+            'expectedArray' => ['data-controller' => 'false-controller', 'data-false-controller-is-enabled-value' => 'false'],
         ];
 
         yield 'true-attribute-value-renders-true' => [
             'dataOrControllerName' => 'true-controller',
             'controllerValues' => ['isEnabled' => true],
-            'expected' => 'data-controller="true-controller" data-true-controller-is-enabled-value="true"',
+            'expectedString' => 'data-controller="true-controller" data-true-controller-is-enabled-value="true"',
+            'expectedArray' => ['data-controller' => 'true-controller', 'data-true-controller-is-enabled-value' => 'true'],
         ];
 
         yield 'null-attribute-value-does-not-render' => [
             'dataOrControllerName' => 'null-controller',
             'controllerValues' => ['firstName' => null],
-            'expected' => 'data-controller="null-controller"',
+            'expectedString' => 'data-controller="null-controller"',
+            'expectedArray' => ['data-controller' => 'null-controller'],
         ];
     }
 
     /**
      * @dataProvider provideRenderStimulusController
      */
-    public function testRenderStimulusController($dataOrControllerName, array $controllerValues, string $expected)
+    public function testRenderStimulusController($dataOrControllerName, array $controllerValues, string $expectedString, array $expectedArray)
     {
         $kernel = new WebpackEncoreIntegrationTestKernel(true);
         $kernel->boot();
         $twig = $this->getTwigEnvironmentFromBootedKernel($kernel);
 
         $extension = new StimulusTwigExtension();
-        $this->assertSame($expected, $extension->renderStimulusController($twig, $dataOrControllerName, $controllerValues));
+        $dto = $extension->renderStimulusController($twig, $dataOrControllerName, $controllerValues);
+        $this->assertSame($expectedString, (string) $dto);
+        $this->assertSame($expectedArray, $dto->toArray());
+    }
+
+    public function testAppendStimulusController()
+    {
+        $kernel = new WebpackEncoreIntegrationTestKernel(true);
+        $kernel->boot();
+        $twig = $this->getTwigEnvironmentFromBootedKernel($kernel);
+
+        $extension = new StimulusTwigExtension();
+        $dto = $extension->renderStimulusController($twig, 'my-controller', ['myValue' => 'scalar-value']);
+        $this->assertSame(
+            'data-controller="my-controller another-controller" data-my-controller-my-value-value="scalar-value" data-another-controller-another-value-value="scalar-value&#x20;2"',
+            (string) $extension->appendStimulusController($dto, 'another-controller', ['another-value' => 'scalar-value 2'])
+        );
     }
 
     public function provideRenderStimulusAction()
@@ -323,14 +351,27 @@ class IntegrationTest extends TestCase
             'dataOrControllerName' => 'my-controller',
             'actionName' => 'onClick',
             'eventName' => null,
-            'expected' => 'data-action="my-controller#onClick"',
+            'parameters' => [],
+            'expectedString' => 'data-action="my-controller#onClick"',
+            'expectedArray' => ['data-action' => 'my-controller#onClick'],
         ];
 
         yield 'with custom event' => [
             'dataOrControllerName' => 'my-controller',
             'actionName' => 'onClick',
             'eventName' => 'click',
-            'expected' => 'data-action="click->my-controller#onClick"',
+            'parameters' => [],
+            'expectedString' => 'data-action="click->my-controller#onClick"',
+            'expectedArray' => ['data-action' => 'click->my-controller#onClick'],
+        ];
+
+        yield 'with parameters' => [
+            'dataOrControllerName' => 'my-controller',
+            'actionName' => 'onClick',
+            'eventName' => null,
+            'parameters' => ['bool-param' => true, 'int-param' => 4, 'string-param' => 'test'],
+            'expectedString' => 'data-action="my-controller#onClick" data-my-controller-bool-param-param="true" data-my-controller-int-param-param="4" data-my-controller-string-param-param="test"',
+            'expectedArray' => ['data-action' => 'my-controller#onClick', 'data-my-controller-bool-param-param' => 'true', 'data-my-controller-int-param-param' => '4', 'data-my-controller-string-param-param' => 'test'],
         ];
 
         yield 'multiple actions, with default event' => [
@@ -341,7 +382,9 @@ class IntegrationTest extends TestCase
             ],
             'actionName' => null,
             'eventName' => null,
-            'expected' => 'data-action="my-controller#onClick my-second-controller#onClick my-second-controller#onSomethingElse foo--bar-controller#onClick"',
+            'parameters' => [],
+            'expectedString' => 'data-action="my-controller#onClick my-second-controller#onClick my-second-controller#onSomethingElse foo--bar-controller#onClick"',
+            'expectedArray' => ['data-action' => 'my-controller#onClick my-second-controller#onClick my-second-controller#onSomethingElse foo--bar-controller#onClick'],
         ];
 
         yield 'multiple actions, with custom event' => [
@@ -353,7 +396,9 @@ class IntegrationTest extends TestCase
             ],
             'actionName' => null,
             'eventName' => null,
-            'expected' => 'data-action="click->my-controller#onClick click->my-second-controller#onClick change->my-second-controller#onSomethingElse resize@window->resize-controller#onWindowResize click->foo--bar-controller#onClick"',
+            'parameters' => [],
+            'expectedString' => 'data-action="click->my-controller#onClick click->my-second-controller#onClick change->my-second-controller#onSomethingElse resize@window->resize-controller#onWindowResize click->foo--bar-controller#onClick"',
+            'expectedArray' => ['data-action' => 'click->my-controller#onClick click->my-second-controller#onClick change->my-second-controller#onSomethingElse resize@window->resize-controller#onWindowResize click->foo--bar-controller#onClick'],
         ];
 
         yield 'multiple actions, with default and custom event' => [
@@ -365,35 +410,57 @@ class IntegrationTest extends TestCase
             ],
             'actionName' => null,
             'eventName' => null,
-            'expected' => 'data-action="click->my-controller#onClick my-second-controller#onClick click->my-second-controller#onAnotherClick change->my-second-controller#onSomethingElse resize@window->resize-controller#onWindowResize click->foo--bar-controller#onClick"',
+            'parameters' => [],
+            'expectedString' => 'data-action="click->my-controller#onClick my-second-controller#onClick click->my-second-controller#onAnotherClick change->my-second-controller#onSomethingElse resize@window->resize-controller#onWindowResize click->foo--bar-controller#onClick"',
+            'expectedArray' => ['data-action' => 'click->my-controller#onClick my-second-controller#onClick click->my-second-controller#onAnotherClick change->my-second-controller#onSomethingElse resize@window->resize-controller#onWindowResize click->foo--bar-controller#onClick'],
         ];
 
         yield 'normalize-name, with default event' => [
             'dataOrControllerName' => '@symfony/ux-dropzone/dropzone',
             'actionName' => 'onClick',
             'eventName' => null,
-            'expected' => 'data-action="symfony--ux-dropzone--dropzone#onClick"',
+            'parameters' => [],
+            'expectedString' => 'data-action="symfony--ux-dropzone--dropzone#onClick"',
+            'expectedArray' => ['data-action' => 'symfony--ux-dropzone--dropzone#onClick'],
         ];
 
         yield 'normalize-name, with custom event' => [
             'dataOrControllerName' => '@symfony/ux-dropzone/dropzone',
             'actionName' => 'onClick',
             'eventName' => 'click',
-            'expected' => 'data-action="click->symfony--ux-dropzone--dropzone#onClick"',
+            'parameters' => [],
+            'expectedString' => 'data-action="click->symfony--ux-dropzone--dropzone#onClick"',
+            'expectedArray' => ['data-action' => 'click->symfony--ux-dropzone--dropzone#onClick'],
         ];
     }
 
     /**
      * @dataProvider provideRenderStimulusAction
      */
-    public function testRenderStimulusAction($dataOrControllerName, ?string $actionName, ?string $eventName, string $expected)
+    public function testRenderStimulusAction($dataOrControllerName, ?string $actionName, ?string $eventName, array $parameters, string $expectedString, array $expectedArray)
     {
         $kernel = new WebpackEncoreIntegrationTestKernel(true);
         $kernel->boot();
         $twig = $this->getTwigEnvironmentFromBootedKernel($kernel);
 
         $extension = new StimulusTwigExtension();
-        $this->assertSame($expected, $extension->renderStimulusAction($twig, $dataOrControllerName, $actionName, $eventName));
+        $dto = $extension->renderStimulusAction($twig, $dataOrControllerName, $actionName, $eventName, $parameters);
+        $this->assertSame($expectedString, (string) $dto);
+        $this->assertSame($expectedArray, $dto->toArray());
+    }
+
+    public function testAppendStimulusAction()
+    {
+        $kernel = new WebpackEncoreIntegrationTestKernel(true);
+        $kernel->boot();
+        $twig = $this->getTwigEnvironmentFromBootedKernel($kernel);
+
+        $extension = new StimulusTwigExtension();
+        $dto = $extension->renderStimulusAction($twig, 'my-controller', 'onClick', 'click');
+        $this->assertSame(
+            'data-action="click->my-controller#onClick change->my-second-controller#onSomethingElse"',
+            (string) $extension->appendStimulusAction($dto, 'my-second-controller', 'onSomethingElse', 'change')
+        );
     }
 
     public function provideRenderStimulusTarget()
@@ -401,13 +468,15 @@ class IntegrationTest extends TestCase
         yield 'simple' => [
             'dataOrControllerName' => 'my-controller',
             'targetName' => 'myTarget',
-            'expected' => 'data-my-controller-target="myTarget"',
+            'expectedString' => 'data-my-controller-target="myTarget"',
+            'expectedArray' => ['data-my-controller-target' => 'myTarget'],
         ];
 
         yield 'normalize-name' => [
             'dataOrControllerName' => '@symfony/ux-dropzone/dropzone',
             'targetName' => 'myTarget',
-            'expected' => 'data-symfony--ux-dropzone--dropzone-target="myTarget"',
+            'expectedString' => 'data-symfony--ux-dropzone--dropzone-target="myTarget"',
+            'expectedArray' => ['data-symfony--ux-dropzone--dropzone-target' => 'myTarget'],
         ];
 
         yield 'multiple' => [
@@ -416,21 +485,41 @@ class IntegrationTest extends TestCase
                 '@symfony/ux-dropzone/dropzone' => 'anotherTarget fooTarget',
             ],
             'targetName' => null,
-            'expected' => 'data-my-controller-target="myTarget" data-symfony--ux-dropzone--dropzone-target="anotherTarget&#x20;fooTarget"',
+            'expectedString' => 'data-my-controller-target="myTarget" data-symfony--ux-dropzone--dropzone-target="anotherTarget&#x20;fooTarget"',
+            'expectedArray' => [
+                'data-my-controller-target' => 'myTarget',
+                'data-symfony--ux-dropzone--dropzone-target' => 'anotherTarget&#x20;fooTarget',
+            ],
         ];
     }
 
     /**
      * @dataProvider provideRenderStimulusTarget
      */
-    public function testRenderStimulusTarget($dataOrControllerName, ?string $targetName, string $expected)
+    public function testRenderStimulusTarget($dataOrControllerName, ?string $targetName, string $expectedString, array $expectedArray)
     {
         $kernel = new WebpackEncoreIntegrationTestKernel(true);
         $kernel->boot();
         $twig = $this->getTwigEnvironmentFromBootedKernel($kernel);
 
         $extension = new StimulusTwigExtension();
-        $this->assertSame($expected, $extension->renderStimulusTarget($twig, $dataOrControllerName, $targetName));
+        $dto = $extension->renderStimulusTarget($twig, $dataOrControllerName, $targetName);
+        $this->assertSame($expectedString, (string) $dto);
+        $this->assertSame($expectedArray, $dto->toArray());
+    }
+
+    public function testAppendStimulusTarget()
+    {
+        $kernel = new WebpackEncoreIntegrationTestKernel(true);
+        $kernel->boot();
+        $twig = $this->getTwigEnvironmentFromBootedKernel($kernel);
+
+        $extension = new StimulusTwigExtension();
+        $dto = $extension->renderStimulusTarget($twig, 'my-controller', 'myTarget');
+        $this->assertSame(
+            'data-my-controller-target="myTarget" data-symfony--ux-dropzone--dropzone-target="anotherTarget&#x20;fooTarget"',
+            (string) $extension->appendStimulusTarget($dto, '@symfony/ux-dropzone/dropzone', 'anotherTarget fooTarget')
+        );
     }
 
     private function getContainerFromBootedKernel(WebpackEncoreIntegrationTestKernel $kernel)


### PR DESCRIPTION
Hi everyone,

This PR has several goals:

* make `stimulus_action()` handle action parameters
* add Stimulus Twig filters (so you can e.g. pass different parameters to different actions) (closes #159)
* make Stimulus functions/filters return a Stringable DTO...
* so you can retrieve attributes from these functions/filters as an array (using `.toArray()`), which is helpful for forms (closes #176)
