### PR TITLE
CI tools: add CONTRIBUTING.md & allow easily running tools locally

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,11 @@
-/.github
+/.github export-ignore
 /tests export-ignore
+/tools export-ignore
 /phpunit.xml.dist export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.php-cs-fixer.dist.php export-ignore
-/phpstan.neon.dist
-/phpstan-baseline.neon
-/psalm.baseline.xml
-/psalm.xml
+/phpstan.neon.dist export-ignore
+/phpstan-baseline.neon export-ignore
+/psalm.baseline.xml export-ignore
+/psalm.xml export-ignore

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,13 +15,18 @@ jobs:
         with:
           php-version: 8.0
           coverage: none
-          tools: phpstan:0.12.92, cs2pr
+          tools: cs2pr
 
       - name: Download dependencies
         uses: ramsey/composer-install@v1
 
+      - name: Install PHPStan
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: "--working-dir=tools/phpstan"
+
       - name: PHPStan
-        run: phpstan analyze --no-progress --error-format=checkstyle | cs2pr
+        run: tools/phpstan/vendor/bin/phpstan analyze --no-progress --error-format=checkstyle | cs2pr
 
   php-cs-fixer:
     name: PHP-CS-Fixer
@@ -36,10 +41,15 @@ jobs:
         with:
           php-version: 8.0
           coverage: none
-          tools: php-cs-fixer:3.0.0, cs2pr
+          tools: cs2pr
+
+      - name: Install php-cs-fixer
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: "--working-dir=tools/php-cs-fixer"
 
       - name: PHP-CS-Fixer
-        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+        run: tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
   psalm:
     name: Psalm
@@ -58,8 +68,13 @@ jobs:
       - name: Download dependencies
         uses: ramsey/composer-install@v1
 
+      - name: Install psalm
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: "--working-dir=tools/psalm"
+
       - name: Psalm
-        run: psalm --no-progress --php-version=8.0
+        run: tools/psalm/vendor/bin/psalm --no-progress --php-version=8.0
 
   composer-normalize:
     name: Composer Normalize

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 composer.lock
 phpunit.xml
+tools/*/composer.lock
+tools/*/vendor
 vendor/
 .php-cs-fixer.cache
 .phpunit.result.cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+Contributing
+------------
+
+When contributing, you can fix some things that will be detected by CI anyway *before* sending your pull request.
+
+The following tools will be installed in the `tools` directory, so they don't share the bundle requirements.
+
+PHPStan
+=======
+
+```bash
+composer install --working-dir=tools/phpstan
+tools/phpstan/vendor/bin/phpstan analyze
+# Based on the results, you may want to update the baseline
+tools/phpstan/vendor/bin/phpstan analyze --generate-baseline
+```
+
+PHP CS Fixer
+============
+
+```bash
+composer install --working-dir=tools/php-cs-fixer
+# Check what can be fixed
+tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --diff
+# Fix them
+tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --diff
+```
+
+Psalm
+=====
+
+```bash
+composer install --working-dir=tools/psalm
+tools/psalm/vendor/bin/psalm --php-version=8.0
+```

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: src/Asset/EntrypointLookup.php
 
 		-
-			message: "#^Method Symfony\\\\Bundle\\\\FrameworkBundle\\\\CacheWarmer\\\\AbstractPhpFileCacheWarmer\\:\\:__construct\\(\\) invoked with 2 parameters, 1 required\\.$#"
-			count: 1
-			path: src/CacheWarmer/EntrypointCacheWarmer.php
-
-		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:children\\(\\)\\.$#"
 			count: 1
 			path: src/DependencyInjection/Configuration.php
@@ -46,12 +41,12 @@ parameters:
 			path: src/EventListener/PreLoadAssetsEventListener.php
 
 		-
-			message: "#^PHPDoc tag @var for variable \\$linkProvider contains unknown class Fig\\\\Link\\\\GenericLinkProvider\\.$#"
+			message: "#^Method Symfony\\\\WebpackEncoreBundle\\\\EventListener\\\\PreLoadAssetsEventListener\\:\\:createLink\\(\\) has invalid return type Fig\\\\Link\\\\Link\\.$#"
 			count: 1
 			path: src/EventListener/PreLoadAssetsEventListener.php
 
 		-
-			message: "#^Return typehint of method Symfony\\\\WebpackEncoreBundle\\\\EventListener\\\\PreLoadAssetsEventListener\\:\\:createLink\\(\\) has invalid type Fig\\\\Link\\\\Link\\.$#"
+			message: "#^PHPDoc tag @var for variable \\$linkProvider contains unknown class Fig\\\\Link\\\\GenericLinkProvider\\.$#"
 			count: 1
 			path: src/EventListener/PreLoadAssetsEventListener.php
 

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "friendsofphp/php-cs-fixer": "^3.8"
+    }
+}

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpstan/phpstan": "^1.7"
+    }
+}

--- a/tools/psalm/composer.json
+++ b/tools/psalm/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "vimeo/psalm": "^4.23.0"
+    }
+}


### PR DESCRIPTION
Hi,

I wanted to make this PR because when I got errors in CI for an other one, I wondered how to trigger them locally... and it wasn't as easy as I thought :)

So like it's done in Maker bundle, I added most of these tools in their own directory, made CI use these configured tools (instead of loading them from shivammathur/setup-php so versions are synced) & added docs in CONTRIBUTING.md file.

I also upgraded these tools & fixed the .gitattributes, I hope it's okay :) 