### PR TITLE
Disable strict mode by default

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -49,7 +49,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('strict_mode')
                     ->info('Throw an exception if the entrypoints.json file is missing or an entry is missing from the data')
-                    ->defaultTrue()
+                    ->defaultFalse()
                 ->end()
                 ->arrayNode('builds')
                     ->useAttributeAsKey('name')


### PR DESCRIPTION
For consistency with the strict mode of the asset component, which is disabled by default.

Related to https://github.com/symfony/recipes/pull/1087
