### PR TITLE
[ci] fix flex plugin & legacy stimulus tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
             coverage: "none"
             php-version: "${{ matrix.php-version }}"
 
+      - name: Allow Flex Plugin
+        run: |
+          composer global config --no-plugins allow-plugins.symfony/flex true
+
       - name: Install Global Dependencies
         run: |
           composer global require --no-progress --no-scripts --no-plugins symfony/flex @dev

--- a/src/Dto/AbstractStimulusDto.php
+++ b/src/Dto/AbstractStimulusDto.php
@@ -39,7 +39,7 @@ abstract class AbstractStimulusDto implements \Stringable
     {
         if ($value instanceof \Stringable || (\is_object($value) && \is_callable([$value, '__toString']))) {
             $value = (string) $value;
-        } elseif (!is_scalar($value)) {
+        } elseif (!\is_scalar($value)) {
             $value = json_encode($value);
         } elseif (\is_bool($value)) {
             $value = $value ? 'true' : 'false';


### PR DESCRIPTION
- adds `flex` to composers allowed plugins
- moves Stimulus `action`, `controller`, & `target` test cases w/ array's as the first arg to legacy tests. (silence deprecation's in CI)