### PR TITLE
Stimulus: move deprecations from DTOs to filters/functions

### DIFF
--- a/src/Dto/StimulusActionsDto.php
+++ b/src/Dto/StimulusActionsDto.php
@@ -32,7 +32,6 @@ final class StimulusActionsDto extends AbstractStimulusDto
         if (\is_string($dataOrControllerName)) {
             $data = [$dataOrControllerName => null === $eventName ? [[$actionName]] : [[$eventName => $actionName]]];
         } else {
-            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_action() is deprecated.');
             if ($actionName || $eventName || $parameters) {
                 throw new \InvalidArgumentException('You cannot pass a string to the second or third argument nor an array to the fourth argument while passing an array to the first argument of stimulus_action(): check the documentation.');
             }

--- a/src/Dto/StimulusControllersDto.php
+++ b/src/Dto/StimulusControllersDto.php
@@ -30,7 +30,6 @@ final class StimulusControllersDto extends AbstractStimulusDto
         if (\is_string($dataOrControllerName)) {
             $data = [$dataOrControllerName => $controllerValues];
         } else {
-            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_controller() is deprecated.');
             if ($controllerValues) {
                 throw new \InvalidArgumentException('You cannot pass an array to the first and second argument of stimulus_controller(): check the documentation.');
             }

--- a/src/Dto/StimulusTargetsDto.php
+++ b/src/Dto/StimulusTargetsDto.php
@@ -29,7 +29,6 @@ final class StimulusTargetsDto extends AbstractStimulusDto
         if (\is_string($dataOrControllerName)) {
             $data = [$dataOrControllerName => $targetNames];
         } else {
-            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_target() is deprecated.');
             if ($targetNames) {
                 throw new \InvalidArgumentException('You cannot pass a string to the second argument while passing an array to the first argument of stimulus_target(): check the documentation.');
             }

--- a/src/Twig/StimulusTwigExtension.php
+++ b/src/Twig/StimulusTwigExtension.php
@@ -48,6 +48,10 @@ final class StimulusTwigExtension extends AbstractExtension
      */
     public function renderStimulusController(Environment $env, $dataOrControllerName, array $controllerValues = []): StimulusControllersDto
     {
+        if (!\is_string($dataOrControllerName)) {
+            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_controller() is deprecated.');
+        }
+
         $dto = new StimulusControllersDto($env);
         $dto->addController($dataOrControllerName, $controllerValues);
 
@@ -65,6 +69,10 @@ final class StimulusTwigExtension extends AbstractExtension
      */
     public function appendStimulusController(StimulusControllersDto $dto, $dataOrControllerName, array $controllerValues = []): StimulusControllersDto
     {
+        if (!\is_string($dataOrControllerName)) {
+            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_controller() is deprecated.');
+        }
+
         $dto->addController($dataOrControllerName, $controllerValues);
 
         return $dto;
@@ -83,6 +91,10 @@ final class StimulusTwigExtension extends AbstractExtension
      */
     public function renderStimulusAction(Environment $env, $dataOrControllerName, string $actionName = null, string $eventName = null, array $parameters = []): StimulusActionsDto
     {
+        if (!\is_string($dataOrControllerName)) {
+            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_action() is deprecated.');
+        }
+
         $dto = new StimulusActionsDto($env);
         $dto->addAction($dataOrControllerName, $actionName, $eventName, $parameters);
 
@@ -102,6 +114,10 @@ final class StimulusTwigExtension extends AbstractExtension
      */
     public function appendStimulusAction(StimulusActionsDto $dto, $dataOrControllerName, string $actionName = null, string $eventName = null, array $parameters = []): StimulusActionsDto
     {
+        if (!\is_string($dataOrControllerName)) {
+            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_action() is deprecated.');
+        }
+
         $dto->addAction($dataOrControllerName, $actionName, $eventName, $parameters);
 
         return $dto;
@@ -118,6 +134,10 @@ final class StimulusTwigExtension extends AbstractExtension
      */
     public function renderStimulusTarget(Environment $env, $dataOrControllerName, string $targetNames = null): StimulusTargetsDto
     {
+        if (!\is_string($dataOrControllerName)) {
+            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_target() is deprecated.');
+        }
+
         $dto = new StimulusTargetsDto($env);
         $dto->addTarget($dataOrControllerName, $targetNames);
 
@@ -135,6 +155,10 @@ final class StimulusTwigExtension extends AbstractExtension
      */
     public function appendStimulusTarget(StimulusTargetsDto $dto, $dataOrControllerName, string $targetNames = null): StimulusTargetsDto
     {
+        if (!\is_string($dataOrControllerName)) {
+            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_target() is deprecated.');
+        }
+
         $dto->addTarget($dataOrControllerName, $targetNames);
 
         return $dto;


### PR DESCRIPTION
As discussed with @weaverryan on Slack, I'm moving deprecation triggers from DTOs to Twig filters/functions.