### PR TITLE
Moving deprecated code handling for stimulus_ functions into Twig extension

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Variable \\$cached might not be defined\\.$#"
-			count: 1
-			path: src/Asset/EntrypointLookup.php
-
-		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition\\:\\:children\\(\\)\\.$#"
 			count: 1
 			path: src/DependencyInjection/Configuration.php
@@ -21,72 +16,6 @@ parameters:
 			path: src/Dto/AbstractStimulusDto.php
 
 		-
-			message: "#^Call to function is_string\\(\\) with 0 will always evaluate to false\\.$#"
-			count: 1
-			path: src/Dto/StimulusActionsDto.php
-
-		-
-			message: "#^Call to function is_string\\(\\) with array\\{non\\-empty\\-array\\<0\\|string, string\\|null\\>\\} will always evaluate to false\\.$#"
-			count: 1
-			path: src/Dto/StimulusActionsDto.php
-
-		-
-			message: "#^Call to function is_string\\(\\) with non\\-empty\\-array\\<0\\|string, string\\|null\\> will always evaluate to false\\.$#"
+			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
 			count: 2
-			path: src/Dto/StimulusActionsDto.php
-
-		-
-			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
-			count: 1
-			path: src/Dto/StimulusActionsDto.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: src/Dto/StimulusActionsDto.php
-
-		-
-			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
-			count: 1
-			path: src/Dto/StimulusControllersDto.php
-
-		-
-			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
-			count: 1
-			path: src/Dto/StimulusTargetsDto.php
-
-		-
-			message: "#^Call to method withAttribute\\(\\) on an unknown class Fig\\\\Link\\\\Link\\.$#"
-			count: 2
-			path: src/EventListener/PreLoadAssetsEventListener.php
-
-		-
-			message: "#^Call to method withLink\\(\\) on an unknown class Fig\\\\Link\\\\GenericLinkProvider\\.$#"
-			count: 2
-			path: src/EventListener/PreLoadAssetsEventListener.php
-
-		-
-			message: "#^Class Fig\\\\Link\\\\Link not found\\.$#"
-			count: 1
-			path: src/EventListener/PreLoadAssetsEventListener.php
-
-		-
-			message: "#^Instantiated class Fig\\\\Link\\\\GenericLinkProvider not found\\.$#"
-			count: 1
-			path: src/EventListener/PreLoadAssetsEventListener.php
-
-		-
-			message: "#^Instantiated class Fig\\\\Link\\\\Link not found\\.$#"
-			count: 1
-			path: src/EventListener/PreLoadAssetsEventListener.php
-
-		-
-			message: "#^Method Symfony\\\\WebpackEncoreBundle\\\\EventListener\\\\PreLoadAssetsEventListener\\:\\:createLink\\(\\) has invalid return type Fig\\\\Link\\\\Link\\.$#"
-			count: 1
-			path: src/EventListener/PreLoadAssetsEventListener.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$linkProvider contains unknown class Fig\\\\Link\\\\GenericLinkProvider\\.$#"
-			count: 1
-			path: src/EventListener/PreLoadAssetsEventListener.php
-
+			path: src/Twig/StimulusTwigExtension.php

--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -134,7 +134,7 @@ class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProvid
             throw new \InvalidArgumentException(sprintf('Could not find an "entrypoints" key in the "%s" file', $this->entrypointJsonPath));
         }
 
-        if ($this->cache) {
+        if (isset($cached)) {
             $this->cache->save($cached->set($this->entriesData));
         }
 

--- a/src/Dto/StimulusActionsDto.php
+++ b/src/Dto/StimulusActionsDto.php
@@ -17,57 +17,21 @@ final class StimulusActionsDto extends AbstractStimulusDto
     private $parameters = [];
 
     /**
-     * @param string      $controllerName the Stimulus controller name
-     * @param string      $actionName     the action to trigger
-     * @param string|null $eventName      The event to listen to trigger. Optional.
-     * @param array       $parameters     Parameters to pass to the action. Optional.
-     *
-     * @throws \Twig\Error\RuntimeError
+     * @param array $parameters Parameters to pass to the action. Optional.
      */
-    public function addAction($controllerName, string $actionName = null, string $eventName = null, array $parameters = []): void
+    public function addAction(string $controllerName, string $actionName, string $eventName = null, array $parameters = []): void
     {
-        if (\is_string($controllerName)) {
-            $data = [$controllerName => null === $eventName ? [[$actionName]] : [[$eventName => $actionName]]];
-        } else {
-            if ($actionName || $eventName || $parameters) {
-                throw new \InvalidArgumentException('You cannot pass a string to the second or third argument nor an array to the fourth argument while passing an array to the first argument of stimulus_action(): check the documentation.');
-            }
+        $controllerName = $this->getFormattedControllerName($controllerName);
+        $action = $controllerName.'#'.$this->escapeAsHtmlAttr($actionName);
 
-            $data = $controllerName;
-
-            if (!$data) {
-                return;
-            }
+        if (null !== $eventName) {
+            $action = $eventName.'->'.$action;
         }
 
-        foreach ($data as $controllerName => $controllerActions) {
-            $controllerName = $this->getFormattedControllerName($controllerName);
+        $this->actions[] = $action;
 
-            if (\is_string($controllerActions)) {
-                $controllerActions = [[$controllerActions]];
-            }
-
-            foreach ($controllerActions as $possibleEventName => $controllerAction) {
-                if (\is_string($possibleEventName) && \is_string($controllerAction)) {
-                    $controllerAction = [$possibleEventName => $controllerAction];
-                } elseif (\is_string($controllerAction)) {
-                    $controllerAction = [$controllerAction];
-                }
-
-                foreach ($controllerAction as $eventName => $actionName) {
-                    $action = $controllerName.'#'.$this->escapeAsHtmlAttr($actionName);
-
-                    if (\is_string($eventName)) {
-                        $action = $eventName.'->'.$action;
-                    }
-
-                    $this->actions[] = $action;
-                }
-            }
-
-            foreach ($parameters as $name => $value) {
-                $this->parameters['data-'.$controllerName.'-'.$name.'-param'] = $this->getFormattedValue($value);
-            }
+        foreach ($parameters as $name => $value) {
+            $this->parameters['data-'.$controllerName.'-'.$name.'-param'] = $this->getFormattedValue($value);
         }
     }
 

--- a/src/Dto/StimulusControllersDto.php
+++ b/src/Dto/StimulusControllersDto.php
@@ -16,42 +16,20 @@ final class StimulusControllersDto extends AbstractStimulusDto
     private $controllers = [];
     private $values = [];
 
-    /**
-     * @param string $controllerName   the Stimulus controller name
-     * @param array  $controllerValues array of data if a string is passed to the 1st argument
-     *
-     * @throws \Twig\Error\RuntimeError
-     */
-    public function addController($controllerName, array $controllerValues = []): void
+    public function addController(string $controllerName, array $controllerValues = []): void
     {
-        if (\is_string($controllerName)) {
-            $data = [$controllerName => $controllerValues];
-        } else {
-            if ($controllerValues) {
-                throw new \InvalidArgumentException('You cannot pass an array to the first and second argument of stimulus_controller(): check the documentation.');
+        $controllerName = $this->getFormattedControllerName($controllerName);
+        $this->controllers[] = $controllerName;
+
+        foreach ($controllerValues as $key => $value) {
+            if (null === $value) {
+                continue;
             }
 
-            $data = $controllerName;
+            $key = $this->escapeAsHtmlAttr($this->normalizeKeyName($key));
+            $value = $this->getFormattedValue($value);
 
-            if (!$data) {
-                return;
-            }
-        }
-
-        foreach ($data as $controllerName => $controllerValues) {
-            $controllerName = $this->getFormattedControllerName($controllerName);
-            $this->controllers[] = $controllerName;
-
-            foreach ($controllerValues as $key => $value) {
-                if (null === $value) {
-                    continue;
-                }
-
-                $key = $this->escapeAsHtmlAttr($this->normalizeKeyName($key));
-                $value = $this->getFormattedValue($value);
-
-                $this->values['data-'.$controllerName.'-'.$key.'-value'] = $value;
-            }
+            $this->values['data-'.$controllerName.'-'.$key.'-value'] = $value;
         }
     }
 

--- a/src/Dto/StimulusTargetsDto.php
+++ b/src/Dto/StimulusTargetsDto.php
@@ -18,30 +18,12 @@ final class StimulusTargetsDto extends AbstractStimulusDto
     /**
      * @param string      $controllerName the Stimulus controller name
      * @param string|null $targetNames    The space-separated list of target names if a string is passed to the 1st argument. Optional.
-     *
-     * @throws \Twig\Error\RuntimeError
      */
-    public function addTarget($controllerName, string $targetNames = null): void
+    public function addTarget(string $controllerName, string $targetNames = null): void
     {
-        if (\is_string($controllerName)) {
-            $data = [$controllerName => $targetNames];
-        } else {
-            if ($targetNames) {
-                throw new \InvalidArgumentException('You cannot pass a string to the second argument while passing an array to the first argument of stimulus_target(): check the documentation.');
-            }
+        $controllerName = $this->getFormattedControllerName($controllerName);
 
-            $data = $controllerName;
-
-            if (!$data) {
-                return;
-            }
-        }
-
-        foreach ($data as $controllerName => $targetNames) {
-            $controllerName = $this->getFormattedControllerName($controllerName);
-
-            $this->targets['data-'.$controllerName.'-target'] = $this->escapeAsHtmlAttr($targetNames);
-        }
+        $this->targets['data-'.$controllerName.'-target'] = $this->escapeAsHtmlAttr($targetNames);
     }
 
     public function __toString(): string

--- a/src/EventListener/PreLoadAssetsEventListener.php
+++ b/src/EventListener/PreLoadAssetsEventListener.php
@@ -9,8 +9,6 @@
 
 namespace Symfony\WebpackEncoreBundle\EventListener;
 
-use Fig\Link\GenericLinkProvider as FigGenericLinkProvider;
-use Fig\Link\Link as FigLink;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\WebLink\GenericLinkProvider;
@@ -43,18 +41,17 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         if (null === $linkProvider = $request->attributes->get('_links')) {
             $request->attributes->set(
                 '_links',
-                // For backwards-compat with symfony/web-link 4.3 and lower
-                class_exists(GenericLinkProvider::class) ? new GenericLinkProvider() : new FigGenericLinkProvider()
+                new GenericLinkProvider()
             );
         }
 
-        /** @var GenericLinkProvider|FigGenericLinkProvider $linkProvider */
+        /** @var GenericLinkProvider $linkProvider */
         $linkProvider = $request->attributes->get('_links');
         $defaultAttributes = $this->tagRenderer->getDefaultAttributes();
         $crossOrigin = $defaultAttributes['crossorigin'] ?? false;
 
         foreach ($this->tagRenderer->getRenderedScripts() as $href) {
-            $link = ($this->createLink('preload', $href))->withAttribute('as', 'script');
+            $link = $this->createLink('preload', $href)->withAttribute('as', 'script');
 
             if (false !== $crossOrigin) {
                 $link = $link->withAttribute('crossorigin', $crossOrigin);
@@ -64,7 +61,7 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         }
 
         foreach ($this->tagRenderer->getRenderedStyles() as $href) {
-            $link = ($this->createLink('preload', $href))->withAttribute('as', 'style');
+            $link = $this->createLink('preload', $href)->withAttribute('as', 'style');
 
             if (false !== $crossOrigin) {
                 $link = $link->withAttribute('crossorigin', $crossOrigin);
@@ -84,15 +81,8 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         ];
     }
 
-    /**
-     * For backwards-compat with symfony/web-link 4.3 and lower.
-     *
-     * @return Link|FigLink
-     */
-    private function createLink(string $rel, string $href)
+    private function createLink(string $rel, string $href): Link
     {
-        $class = class_exists(Link::class) ? Link::class : FigLink::class;
-
-        return new $class($rel, $href);
+        return new Link($rel, $href);
     }
 }

--- a/src/Twig/StimulusTwigExtension.php
+++ b/src/Twig/StimulusTwigExtension.php
@@ -39,32 +39,26 @@ final class StimulusTwigExtension extends AbstractExtension
 
     /**
      * @param string $controllerName   the Stimulus controller name
-     * @param array  $controllerValues array of data if a string is passed to the 1st argument
-     *
-     * @throws \Twig\Error\RuntimeError
+     * @param array  $controllerValues array of controller values
      */
     public function renderStimulusController(Environment $env, $controllerName, array $controllerValues = []): StimulusControllersDto
     {
-        if (!\is_string($dataOrControllerName)) {
-            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_controller() is deprecated.');
-        }
-
         $dto = new StimulusControllersDto($env);
-        $dto->addController($controllerName, $controllerValues);
 
-        return $dto;
-    }
-
-    /**
-     * @param string $controllerName   the Stimulus controller name
-     * @param array  $controllerValues array of data if a string is passed to the 1st argument
-     *
-     * @throws \Twig\Error\RuntimeError
-     */
-    public function appendStimulusController(StimulusControllersDto $dto, $controllerName, array $controllerValues = []): StimulusControllersDto
-    {
-        if (!\is_string($controllerName)) {
+        if (\is_array($controllerName)) {
             trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_controller() is deprecated.');
+
+            if ($controllerValues) {
+                throw new \InvalidArgumentException('You cannot pass an array to the first and second argument of stimulus_controller(): check the documentation.');
+            }
+
+            $data = $controllerName;
+
+            foreach ($data as $controllerName => $controllerValues) {
+                $dto->addController($controllerName, $controllerValues);
+            }
+
+            return $dto;
         }
 
         $dto->addController($controllerName, $controllerValues);
@@ -73,39 +67,58 @@ final class StimulusTwigExtension extends AbstractExtension
     }
 
     /**
-     * @param string      $controllerName the Stimulus controller name
-     * @param string      $actionName     the action to trigger
-     * @param string|null $eventName      The event to listen to trigger. Optional.
-     * @param array       $parameters     Parameters to pass to the action. Optional.
-     *
-     * @throws \Twig\Error\RuntimeError
+     * @param array $parameters Parameters to pass to the action. Optional.
      */
     public function renderStimulusAction(Environment $env, $controllerName, string $actionName = null, string $eventName = null, array $parameters = []): StimulusActionsDto
     {
-        if (!\is_string($dataOrControllerName)) {
+        $dto = new StimulusActionsDto($env);
+        if (\is_array($controllerName)) {
             trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_action() is deprecated.');
+
+            if ($actionName || $eventName || $parameters) {
+                throw new \InvalidArgumentException('You cannot pass a string to the second or third argument nor an array to the fourth argument while passing an array to the first argument of stimulus_action(): check the documentation.');
+            }
+
+            $data = $controllerName;
+
+            foreach ($data as $controllerName => $controllerActions) {
+                if (\is_string($controllerActions)) {
+                    $controllerActions = [[$controllerActions]];
+                }
+
+                foreach ($controllerActions as $possibleEventName => $controllerAction) {
+                    if (\is_string($possibleEventName) && \is_string($controllerAction)) {
+                        $controllerAction = [$possibleEventName => $controllerAction];
+                    } elseif (\is_string($controllerAction)) {
+                        $controllerAction = [$controllerAction];
+                    }
+
+                    foreach ($controllerAction as $eventName => $actionName) {
+                        $dto->addAction($controllerName, $actionName, \is_string($eventName) ? $eventName : null);
+                    }
+                }
+            }
+
+            return $dto;
         }
 
-        $dto = new StimulusActionsDto($env);
         $dto->addAction($controllerName, $actionName, $eventName, $parameters);
 
         return $dto;
     }
 
-    /**
-     * @param string      $controllerName the Stimulus controller name
-     * @param string      $actionName     the action to trigger
-     * @param string|null $eventName      The event to listen to trigger. Optional.
-     * @param array       $parameters     Parameters to pass to the action. Optional.
-     *
-     * @throws \Twig\Error\RuntimeError
-     */
-    public function appendStimulusAction(StimulusActionsDto $dto, $controllerName, string $actionName = null, string $eventName = null, array $parameters = []): StimulusActionsDto
+    public function appendStimulusController(StimulusControllersDto $dto, string $controllerName, array $controllerValues = []): StimulusControllersDto
     {
-        if (!\is_string($controllerName)) {
-            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_action() is deprecated.');
-        }
+        $dto->addController($controllerName, $controllerValues);
 
+        return $dto;
+    }
+
+    /**
+     * @param array $parameters Parameters to pass to the action. Optional.
+     */
+    public function appendStimulusAction(StimulusActionsDto $dto, string $controllerName, string $actionName, string $eventName = null, array $parameters = []): StimulusActionsDto
+    {
         $dto->addAction($controllerName, $actionName, $eventName, $parameters);
 
         return $dto;
@@ -114,16 +127,26 @@ final class StimulusTwigExtension extends AbstractExtension
     /**
      * @param string      $controllerName the Stimulus controller name
      * @param string|null $targetNames    The space-separated list of target names if a string is passed to the 1st argument. Optional.
-     *
-     * @throws \Twig\Error\RuntimeError
      */
     public function renderStimulusTarget(Environment $env, $controllerName, string $targetNames = null): StimulusTargetsDto
     {
-        if (!\is_string($dataOrControllerName)) {
+        $dto = new StimulusTargetsDto($env);
+        if (\is_array($controllerName)) {
             trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_target() is deprecated.');
+
+            if ($targetNames) {
+                throw new \InvalidArgumentException('You cannot pass a string to the second argument while passing an array to the first argument of stimulus_target(): check the documentation.');
+            }
+
+            $data = $controllerName;
+
+            foreach ($data as $controllerName => $targetNames) {
+                $dto->addTarget($controllerName, $targetNames);
+            }
+
+            return $dto;
         }
 
-        $dto = new StimulusTargetsDto($env);
         $dto->addTarget($controllerName, $targetNames);
 
         return $dto;
@@ -132,15 +155,9 @@ final class StimulusTwigExtension extends AbstractExtension
     /**
      * @param string      $controllerName the Stimulus controller name
      * @param string|null $targetNames    The space-separated list of target names if a string is passed to the 1st argument. Optional.
-     *
-     * @throws \Twig\Error\RuntimeError
      */
-    public function appendStimulusTarget(StimulusTargetsDto $dto, $controllerName, string $targetNames = null): StimulusTargetsDto
+    public function appendStimulusTarget(StimulusTargetsDto $dto, string $controllerName, string $targetNames = null): StimulusTargetsDto
     {
-        if (!\is_string($controllerName)) {
-            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_target() is deprecated.');
-        }
-
         $dto->addTarget($controllerName, $targetNames);
 
         return $dto;

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -646,6 +646,9 @@ abstract class AbstractWebpackEncoreIntegrationTestKernel extends Kernel
                 'utf8' => true,
             ];
         }
+        if (self::VERSION_ID >= 60200) {
+            $frameworkConfig['catch_all_throwables'] = true;
+        }
         $container->loadFromExtension('framework', $frameworkConfig);
 
         $container->loadFromExtension('twig', [


### PR DESCRIPTION
Hi!

This follows up on @jmsche continued work with the Stimulus functions. Basically:

A) The only deprecated should be in the Twig extension: we deprecated passing certain args as an array there. And so, the code to "normalize" the deprecated arguments should live there.

B) This allows the DTO classes to be "pure" classes that are not encumbered by any deprecation later.

Cheers!