### PR TITLE
Hook to collect stimulus-controller data

### DIFF
--- a/src/DataCollector/StimulusCollector.php
+++ b/src/DataCollector/StimulusCollector.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\DataCollector;
+
+use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\WebpackEncoreBundle\Event\RenderStimulusControllerEvents;
+use Symfony\WebpackEncoreBundle\EventListener\RenderStimulusControllerListener;
+
+class StimulusCollector extends AbstractDataCollector
+{
+    private RenderStimulusControllerEvents $events;
+
+    public function __construct(RenderStimulusControllerListener $logger)
+    {
+        $this->events = $logger->getEvents();
+    }
+
+    public function collect(Request $request, Response $response, \Throwable $exception = null)
+    {
+        $this->data['events'] = $this->events;
+    }
+
+    public static function getTemplate(): ?string
+    {
+        return '@Symfony/WebpackEncoreBundle/Resources/collector/ux.html.twig';
+    }
+
+    public function getName(): string
+    {
+        return 'ux';
+    }
+}

--- a/src/DataCollector/StimulusCollector.php
+++ b/src/DataCollector/StimulusCollector.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\WebpackEncoreBundle\DataCollector;
 
 use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
@@ -10,7 +17,10 @@ use Symfony\WebpackEncoreBundle\EventListener\RenderStimulusControllerListener;
 
 class StimulusCollector extends AbstractDataCollector
 {
-    private RenderStimulusControllerEvents $events;
+    /**
+     * @var RenderStimulusControllerEvents
+     */
+    private $events;
 
     public function __construct(RenderStimulusControllerListener $logger)
     {
@@ -20,11 +30,6 @@ class StimulusCollector extends AbstractDataCollector
     public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
         $this->data['events'] = $this->events;
-    }
-
-    public static function getTemplate(): ?string
-    {
-        return '@Symfony/WebpackEncoreBundle/Resources/collector/ux.html.twig';
     }
 
     public function getName(): string

--- a/src/Event/RenderStimulusControllerEvent.php
+++ b/src/Event/RenderStimulusControllerEvent.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\WebpackEncoreBundle\Event;
 
 final class RenderStimulusControllerEvent
@@ -21,17 +28,17 @@ final class RenderStimulusControllerEvent
 
     public function isController()
     {
-        return $this->type === self::TYPE_CONTROLLER;
+        return self::TYPE_CONTROLLER === $this->type;
     }
 
     public function isAction()
     {
-        return $this->type === self::TYPE_ACTION;
+        return self::TYPE_ACTION === $this->type;
     }
 
     public function isTarget()
     {
-        return $this->type === self::TYPE_TARGET;
+        return self::TYPE_TARGET === $this->type;
     }
 
     public function getControllerName()

--- a/src/Event/RenderStimulusControllerEvent.php
+++ b/src/Event/RenderStimulusControllerEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\Event;
+
+final class RenderStimulusControllerEvent
+{
+    public const TYPE_CONTROLLER = 'controller';
+    public const TYPE_ACTION = 'action';
+    public const TYPE_TARGET = 'target';
+
+    private $type;
+    private $controllerName;
+    private $values;
+
+    public function __construct(string $type, string $controllerName, $values)
+    {
+        $this->type = $type;
+        $this->controllerName = $controllerName;
+        $this->values = $values;
+    }
+
+    public function isController()
+    {
+        return $this->type === self::TYPE_CONTROLLER;
+    }
+
+    public function isAction()
+    {
+        return $this->type === self::TYPE_ACTION;
+    }
+
+    public function isTarget()
+    {
+        return $this->type === self::TYPE_TARGET;
+    }
+
+    public function getControllerName()
+    {
+        return $this->controllerName;
+    }
+
+    public function getValues()
+    {
+        return $this->values;
+    }
+}

--- a/src/Event/RenderStimulusControllerEvents.php
+++ b/src/Event/RenderStimulusControllerEvents.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\Event;
+
+final class RenderStimulusControllerEvents
+{
+    /**
+     * @var RenderStimulusControllerEvent[]
+     */
+    private array $events = [];
+
+    public function add(RenderStimulusControllerEvent $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    public function getEvents(string $controllerName = null): array
+    {
+        if (null === $controllerName) {
+            return $this->events;
+        }
+
+        $events = [];
+        foreach ($this->events as $event) {
+            if ($controllerName === $event->getControllerName()) {
+                $events[] = $event;
+            }
+        }
+
+        return $events;
+    }
+}

--- a/src/Event/RenderStimulusControllerEvents.php
+++ b/src/Event/RenderStimulusControllerEvents.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\WebpackEncoreBundle\Event;
 
 final class RenderStimulusControllerEvents
@@ -7,7 +14,7 @@ final class RenderStimulusControllerEvents
     /**
      * @var RenderStimulusControllerEvent[]
      */
-    private array $events = [];
+    private $events = [];
 
     public function add(RenderStimulusControllerEvent $event): void
     {

--- a/src/EventListener/RenderStimulusControllerListener.php
+++ b/src/EventListener/RenderStimulusControllerListener.php
@@ -1,5 +1,12 @@
 <?php
 
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\WebpackEncoreBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -9,7 +16,7 @@ use Symfony\WebpackEncoreBundle\Event\RenderStimulusControllerEvents;
 
 class RenderStimulusControllerListener implements EventSubscriberInterface, ResetInterface
 {
-    private RenderStimulusControllerEvents $events;
+    private $events;
 
     public function __construct()
     {
@@ -31,10 +38,10 @@ class RenderStimulusControllerListener implements EventSubscriberInterface, Rese
         return $this->events;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
-            RenderStimulusControllerEvent::class => ['onRenderController', -255]
+            RenderStimulusControllerEvent::class => ['onRenderController', -255],
         ];
     }
 }

--- a/src/EventListener/RenderStimulusControllerListener.php
+++ b/src/EventListener/RenderStimulusControllerListener.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Symfony\WebpackEncoreBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Service\ResetInterface;
+use Symfony\WebpackEncoreBundle\Event\RenderStimulusControllerEvent;
+use Symfony\WebpackEncoreBundle\Event\RenderStimulusControllerEvents;
+
+class RenderStimulusControllerListener implements EventSubscriberInterface, ResetInterface
+{
+    private RenderStimulusControllerEvents $events;
+
+    public function __construct()
+    {
+        $this->events = new RenderStimulusControllerEvents();
+    }
+
+    public function reset()
+    {
+        $this->events = new RenderStimulusControllerEvents();
+    }
+
+    public function onRenderController(RenderStimulusControllerEvent $event): void
+    {
+        $this->events->add($event);
+    }
+
+    public function getEvents(): RenderStimulusControllerEvents
+    {
+        return $this->events;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            RenderStimulusControllerEvent::class => ['onRenderController', -255]
+        ];
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
         <defaults public="false" />
 
         <service id="webpack_encore.entrypoint_lookup_collection" class="Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollection">
+            <argument /> <!-- build list of entrypoints locator -->
+        </service>
+
+        <service id="webpack_encore.render_stimulus_controller_events" class="Symfony\WebpackEncoreBundle\Event\RenderStimulusControllerEvents">
             <argument /> <!-- build list of entrypoints locator -->
         </service>
 
@@ -38,6 +42,12 @@
 
         <service id="webpack_encore.twig_stimulus_extension" class="Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension">
             <tag name="twig.extension" />
+            <argument type="service" id="event_dispatcher" />
+        </service>
+
+        <service id="webpack_encore.stimulus_controller_collector" class="Symfony\WebpackEncoreBundle\DataCollector\StimulusCollector">
+            <tag name="data_collector" template="@Symfony\WebpackEncoreBundle\Resources\collector\ux.html.twig"/>
+            <argument type="service" id="Symfony\WebpackEncoreBundle\EventListener\RenderStimulusControllerListener"/>
         </service>
 
         <service id="webpack_encore.entrypoint_lookup.cache_warmer" class="Symfony\WebpackEncoreBundle\CacheWarmer\EntrypointCacheWarmer">
@@ -70,6 +80,10 @@
         <service id="Symfony\WebpackEncoreBundle\EventListener\ResetAssetsEventListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="webpack_encore.entrypoint_lookup_collection" />
+        </service>
+
+        <service id="Symfony\WebpackEncoreBundle\EventListener\RenderStimulusControllerListener">
+            <tag name="kernel.event_listener" event="Symfony\WebpackEncoreBundle\Event\RenderStimulusControllerEvent" method="onRenderController"/>
         </service>
     </services>
 </container>

--- a/src/Twig/StimulusTwigExtension.php
+++ b/src/Twig/StimulusTwigExtension.php
@@ -9,21 +9,28 @@
 
 namespace Symfony\WebpackEncoreBundle\Twig;
 
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Contracts\EventDispatcher\Event;
-use Symfony\WebpackEncoreBundle\DataCollector\StimulusCollector;
 use Symfony\WebpackEncoreBundle\Event\RenderStimulusControllerEvent;
-use Symfony\WebpackEncoreBundle\Dto\StimulusActionsDto;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\WebpackEncoreBundle\Dto\StimulusControllersDto;
+use Symfony\WebpackEncoreBundle\Dto\StimulusActionsDto;
 use Symfony\WebpackEncoreBundle\Dto\StimulusTargetsDto;
-use Twig\Environment;
+use Symfony\Contracts\EventDispatcher\Event;
 use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
 use Twig\TwigFunction;
+use Twig\Environment;
+use Twig\TwigFilter;
 
 final class StimulusTwigExtension extends AbstractExtension
 {
-    public function __construct(private EventDispatcherInterface $eventDispatcher){}
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
 
     public function getFunctions(): array
     {
@@ -103,7 +110,7 @@ final class StimulusTwigExtension extends AbstractExtension
                     }
 
                     foreach ($controllerAction as $eventName => $actionName) {
-                        $event = new Event(RenderStimulusControllerEvent::TYPE_ACTION, $controllerName, $actionName);
+                        $event = new RenderStimulusControllerEvent(RenderStimulusControllerEvent::TYPE_ACTION, $controllerName, $actionName);
                         $this->eventDispatcher->dispatch($event);
 
                         $dto->addAction($controllerName, $actionName, \is_string($eventName) ? $eventName : null);

--- a/src/Twig/StimulusTwigExtension.php
+++ b/src/Twig/StimulusTwigExtension.php
@@ -9,6 +9,10 @@
 
 namespace Symfony\WebpackEncoreBundle\Twig;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\WebpackEncoreBundle\DataCollector\StimulusCollector;
+use Symfony\WebpackEncoreBundle\Event\RenderStimulusControllerEvent;
 use Symfony\WebpackEncoreBundle\Dto\StimulusActionsDto;
 use Symfony\WebpackEncoreBundle\Dto\StimulusControllersDto;
 use Symfony\WebpackEncoreBundle\Dto\StimulusTargetsDto;
@@ -19,6 +23,8 @@ use Twig\TwigFunction;
 
 final class StimulusTwigExtension extends AbstractExtension
 {
+    public function __construct(private EventDispatcherInterface $eventDispatcher){}
+
     public function getFunctions(): array
     {
         return [
@@ -55,6 +61,9 @@ final class StimulusTwigExtension extends AbstractExtension
             $data = $controllerName;
 
             foreach ($data as $controllerName => $controllerValues) {
+                $event = new RenderStimulusControllerEvent(RenderStimulusControllerEvent::TYPE_CONTROLLER, $controllerName, $controllerValues);
+                $this->eventDispatcher->dispatch($event);
+
                 $dto->addController($controllerName, $controllerValues);
             }
 
@@ -94,6 +103,9 @@ final class StimulusTwigExtension extends AbstractExtension
                     }
 
                     foreach ($controllerAction as $eventName => $actionName) {
+                        $event = new Event(RenderStimulusControllerEvent::TYPE_ACTION, $controllerName, $actionName);
+                        $this->eventDispatcher->dispatch($event);
+
                         $dto->addAction($controllerName, $actionName, \is_string($eventName) ? $eventName : null);
                     }
                 }
@@ -141,6 +153,9 @@ final class StimulusTwigExtension extends AbstractExtension
             $data = $controllerName;
 
             foreach ($data as $controllerName => $targetNames) {
+                $event = new RenderStimulusControllerEvent(RenderStimulusControllerEvent::TYPE_TARGET, $controllerName, $targetNames);
+                $this->eventDispatcher->dispatch($event);
+
                 $dto->addTarget($controllerName, $targetNames);
             }
 


### PR DESCRIPTION
Q | A
-- | --
Bug fix? | no
New feature? | yes
Tickets | no
License | MIT

This PR comes from a discussion in Slack with @weaverryan (https://symfony-devs.slack.com/archives/C01FN4EQNLX/p1654894746244569). The goal here is to add a hook to ease access to values passed to any stimulus controller. This PR can maybe be followed by a new UX panel or anything able to show the collected values without looking into the code. 