### PR TITLE
Rename catch_all_throwables to handle_all_throwables in test to fix CI

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -665,7 +665,7 @@ abstract class AbstractWebpackEncoreIntegrationTestKernel extends Kernel
             ];
         }
         if (self::VERSION_ID >= 60200) {
-            $frameworkConfig['catch_all_throwables'] = true;
+            $frameworkConfig['handle_all_throwables'] = true;
         }
         $container->loadFromExtension('framework', $frameworkConfig);
 


### PR DESCRIPTION
Little fix required to make CI pass again :) 

The `catch_all_throwables` parameter was renamed by this PR: https://github.com/symfony/symfony/pull/45997