### PR TITLE
Add Twig function and filter for Stimulus Outlets integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,4 +344,38 @@ You can also retrieve the generated attributes as an array, which can be helpful
 {{ form_row(form.password, { attr: stimulus_target('hello-controller', 'a-target').toArray() }) }}
 ```
 
+### stimulus_outlet
+
+The `stimulus_outlet()` Twig function can be used to render [Stimulus Outlets](https://stimulus.hotwired.dev/reference/outlets).
+
+For example:
+
+```twig
+<div {{ stimulus_outlet('controller', 'a-outlet') }}>Hello</div>
+<div {{ stimulus_outlet('controller', 'a-outlet second-outlet') }}>Hello</div>
+
+<!-- would render -->
+<div data-controller-outlet="a-outlet">Hello</div>
+<div data-controller-outlet="a-target second-outlet">Hello</div>
+```
+
+If you have multiple outlets on the same element, you can chain them as there's also a `stimulus_outlet` filter:
+
+```twig
+<div {{ stimulus_outlet('controller', 'a-outlet')|stimulus_outlet('other-controller', 'another-outlet') }}>
+    Hello
+</div>
+
+<!-- would render -->
+<div data-controller-outlet="a-outlet" data-other-controller-outlet="another-outlet">
+    Hello
+</div>
+```
+
+You can also retrieve the generated attributes as an array, which can be helpful e.g. for forms:
+
+```twig
+{{ form_row(form.password, { attr: stimulus_outlet('hello-controller', 'a-outlet').toArray() }) }}
+```
+
 Ok, have fun!

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -17,5 +17,5 @@ parameters:
 
 		-
 			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
-			count: 2
+			count: 3
 			path: src/Twig/StimulusTwigExtension.php

--- a/src/Dto/StimulusOutletsDto.php
+++ b/src/Dto/StimulusOutletsDto.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Dto;
+
+use function array_keys;
+use function array_map;
+use function implode;
+
+final class StimulusOutletsDto extends AbstractStimulusDto
+{
+    private $outlets = [];
+
+    /**
+     * @param string      $controllerName the Stimulus controller name
+     * @param string|null $outletNames    The space-separated list of outlet names if a string is passed to the 1st argument. Optional.
+     */
+    public function addOutlet(string $controllerName, string $outletNames = null): void
+    {
+        $controllerName = $this->getFormattedControllerName($controllerName);
+
+        $this->outlets['data-'.$controllerName.'-outlet'] = $outletNames;
+    }
+
+    public function __toString(): string
+    {
+        if (0 === \count($this->outlets)) {
+            return '';
+        }
+
+        return implode(' ', array_map(function (string $attribute, string $value): string {
+            return $attribute.'="'.$this->escapeAsHtmlAttr($value).'"';
+        }, array_keys($this->outlets), $this->outlets));
+    }
+
+    public function toArray(): array
+    {
+        return $this->outlets;
+    }
+}

--- a/src/Twig/StimulusTwigExtension.php
+++ b/src/Twig/StimulusTwigExtension.php
@@ -11,6 +11,7 @@ namespace Symfony\WebpackEncoreBundle\Twig;
 
 use Symfony\WebpackEncoreBundle\Dto\StimulusActionsDto;
 use Symfony\WebpackEncoreBundle\Dto\StimulusControllersDto;
+use Symfony\WebpackEncoreBundle\Dto\StimulusOutletsDto;
 use Symfony\WebpackEncoreBundle\Dto\StimulusTargetsDto;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
@@ -25,6 +26,7 @@ final class StimulusTwigExtension extends AbstractExtension
             new TwigFunction('stimulus_controller', [$this, 'renderStimulusController'], ['needs_environment' => true, 'is_safe' => ['html_attr']]),
             new TwigFunction('stimulus_action', [$this, 'renderStimulusAction'], ['needs_environment' => true, 'is_safe' => ['html_attr']]),
             new TwigFunction('stimulus_target', [$this, 'renderStimulusTarget'], ['needs_environment' => true, 'is_safe' => ['html_attr']]),
+            new TwigFunction('stimulus_outlet', [$this, 'renderStimulusOutlet'], ['needs_environment' => true, 'is_safe' => ['html_attr']]),
         ];
     }
 
@@ -34,6 +36,7 @@ final class StimulusTwigExtension extends AbstractExtension
             new TwigFilter('stimulus_controller', [$this, 'appendStimulusController'], ['is_safe' => ['html_attr']]),
             new TwigFilter('stimulus_action', [$this, 'appendStimulusAction'], ['is_safe' => ['html_attr']]),
             new TwigFilter('stimulus_target', [$this, 'appendStimulusTarget'], ['is_safe' => ['html_attr']]),
+            new TwigFilter('stimulus_outlet', [$this, 'appendStimulusOutlet'], ['is_safe' => ['html_attr']]),
         ];
     }
 
@@ -155,11 +158,50 @@ final class StimulusTwigExtension extends AbstractExtension
 
     /**
      * @param string      $controllerName the Stimulus controller name
+     * @param string|null $outletNames    The space-separated list of outlet names if a string is passed to the 1st argument. Optional.
+     */
+    public function renderStimulusOutlet(Environment $env, $controllerName, string $outletNames = null): StimulusOutletsDto
+    {
+        $dto = new StimulusOutletsDto($env);
+        if (\is_array($controllerName)) {
+            trigger_deprecation('symfony/webpack-encore-bundle', 'v1.15.0', 'Passing an array as first argument of stimulus_outlet() is deprecated.');
+
+            if ($outletNames) {
+                throw new \InvalidArgumentException('You cannot pass a string to the second argument while passing an array to the first argument of stimulus_outlet(): check the documentation.');
+            }
+
+            $data = $controllerName;
+
+            foreach ($data as $controllerName => $outletNames) {
+                $dto->addOutlet($controllerName, $outletNames);
+            }
+
+            return $dto;
+        }
+
+        $dto->addOutlet($controllerName, $outletNames);
+
+        return $dto;
+    }
+
+    /**
+     * @param string      $controllerName the Stimulus controller name
      * @param string|null $targetNames    The space-separated list of target names if a string is passed to the 1st argument. Optional.
      */
     public function appendStimulusTarget(StimulusTargetsDto $dto, string $controllerName, string $targetNames = null): StimulusTargetsDto
     {
         $dto->addTarget($controllerName, $targetNames);
+
+        return $dto;
+    }
+
+    /**
+     * @param string      $controllerName the Stimulus controller name
+     * @param string|null $outletNames    The space-separated list of outlet names if a string is passed to the 1st argument. Optional.
+     */
+    public function appendStimulusOutlet(StimulusOutletsDto $dto, string $controllerName, string $outletNames = null): StimulusOutletsDto
+    {
+        $dto->addOutlet($controllerName, $outletNames);
 
         return $dto;
     }

--- a/tests/Dto/StimulusOutletsDtoTest.php
+++ b/tests/Dto/StimulusOutletsDtoTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Tests\Dto;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\WebpackEncoreBundle\Dto\StimulusOutletsDto;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class StimulusOutletsDtoTest extends TestCase
+{
+    /**
+     * @var StimulusOutletsDto
+     */
+    private $stimulusOutletsDto;
+
+    protected function setUp(): void
+    {
+        $this->stimulusOutletsDto = new StimulusOutletsDto(new Environment(new ArrayLoader()));
+    }
+
+    public function testToStringEscapingAttributeValues(): void
+    {
+        $this->stimulusOutletsDto->addOutlet('foo', '"');
+        $attributesHtml = (string) $this->stimulusOutletsDto;
+        self::assertSame('data-foo-outlet="&quot;"', $attributesHtml);
+    }
+
+    public function testToArrayNoEscapingAttributeValues(): void
+    {
+        $this->stimulusOutletsDto->addOutlet('foo', '"');
+        $attributesArray = $this->stimulusOutletsDto->toArray();
+        self::assertSame(['data-foo-outlet' => '"'], $attributesArray);
+    }
+}


### PR DESCRIPTION
The Outlets API was introduced in Stimulus release [v3.2.0](https://github.com/hotwired/stimulus/releases/tag/v3.2.0).

This PR intends to ease its integration in Twig templates, just like Stimulus controllers, actions and targets. 