### PR TITLE
Increasing priority of pass to remove before Twig tries to use it

### DIFF
--- a/src/WebpackEncoreBundle.php
+++ b/src/WebpackEncoreBundle.php
@@ -9,6 +9,7 @@
 
 namespace Symfony\WebpackEncoreBundle;
 
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\WebpackEncoreBundle\DependencyInjection\Compiler\RemoveStimulusServicesPass;
@@ -17,6 +18,7 @@ final class WebpackEncoreBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new RemoveStimulusServicesPass());
+        // run before TwigEnvironmentPass to remove the twig extension before it's used
+        $container->addCompilerPass(new RemoveStimulusServicesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
     }
 }


### PR DESCRIPTION
Hi!

In 1.17.0, a compiler pass was added to remove the Twig extension that supplies the `stimulus_` functions if StimulusBundle is installed (because it supplies those instead). However, the priority needs to be higher, else (depending on the order your bundles are installed) Twig might try to use the service *first*... and then we remove it. Results in:

> The service "twig" has a dependency on a non-existent service "webpack_encore.twig_stimulus_
> extension". Did you mean this: "webpack_encore.twig_entry_files_extension"?

Cheers!