### PR TITLE
Relaxing symfony/service-contracts requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/config": "^5.4 || ^6.2",
         "symfony/dependency-injection": "^5.4 || ^6.2",
         "symfony/http-kernel": "^5.4 || ^6.2",
-        "symfony/service-contracts": "^3.0"
+        "symfony/service-contracts": "^1.1.9 || ^2.1.3 || ^3.0"
     },
     "require-dev": {
         "symfony/framework-bundle": "^5.4 || ^6.2",


### PR DESCRIPTION
Fixes #214. For 2.0, I was tightening up & updating version constraints. This one was over-tightened. The 1.1.9 and 2.1.3 versions were when 8.0 support was fixed/added. We only need this contract for the `ResetInterface`, I believe.

Cheers!