### PR TITLE
Patch type declarations (Symfony 7.0)

### DIFF
--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -67,7 +67,7 @@ class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProvid
      *
      * @return void
      */
-    public function reset()
+    public function reset(): void
     {
         $this->returnedFiles = [];
     }

--- a/src/Asset/EntrypointLookupInterface.php
+++ b/src/Asset/EntrypointLookupInterface.php
@@ -27,5 +27,5 @@ interface EntrypointLookupInterface extends ResetInterface
     /**
      * Resets the state of this service.
      */
-    public function reset();
+    public function reset(): void;
 }

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -139,7 +139,7 @@ class TagRenderer implements ResetInterface
     /**
      * @return void
      */
-    public function reset()
+    public function reset(): void
     {
         $this->renderedFiles = [
             'scripts' => [],

--- a/src/CacheWarmer/EntrypointCacheWarmer.php
+++ b/src/CacheWarmer/EntrypointCacheWarmer.php
@@ -24,7 +24,7 @@ class EntrypointCacheWarmer extends AbstractPhpFileCacheWarmer
         parent::__construct($phpArrayFile);
     }
 
-    protected function doWarmUp($cacheDir, ArrayAdapter $arrayAdapter): bool
+    protected function doWarmUp(string $cacheDir, ArrayAdapter $arrayAdapter, ?string $buildDir = null): bool
     {
         foreach ($this->cacheKeys as $cacheKey => $path) {
             // If the file does not exist then just skip past this entry point.

--- a/src/EventListener/ResetAssetsEventListener.php
+++ b/src/EventListener/ResetAssetsEventListener.php
@@ -27,7 +27,7 @@ class ResetAssetsEventListener implements EventSubscriberInterface
         $this->buildNames = $buildNames;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::FINISH_REQUEST => 'resetAssets',
@@ -37,7 +37,7 @@ class ResetAssetsEventListener implements EventSubscriberInterface
     /**
      * @return void
      */
-    public function resetAssets(FinishRequestEvent $event)
+    public function resetAssets(FinishRequestEvent $event): void
     {
         if (!$event->isMainRequest()) {
             return;


### PR DESCRIPTION
Not 100% sure of what i'm doing there.. 

I try to resolve this : https://github.com/symfony/ux/issues/1223

>   PHP Fatal error: Declaration of Symfony\WebpackEncoreBundle\CacheWarmer\EntrypointCacheWarmer::doWarmUp($cacheDir, Symfony\Component\Cache\Adapter\ArrayAdapter $arrayAdapter): bool must be compatible with Symfony\Bundle\FrameworkBundle\CacheWarmer\AbstractPhpFileCacheWarmer::doWarmUp(string $cacheDir, Symfony\Component\Cache\Adapter\ArrayAdapter $arrayAdapter, ?string $buildDir = null): bool in /home/runner/work/ux/ux/src/Turbo/vendor/symfony/webpack-encore-bundle/src/CacheWarmer/EntrypointCacheWarmer.php on line 27



And i follow that : https://symfony.com/blog/symfony-7-0-type-declarations