### PR TITLE
Allow entrypoints.json to be hosted remotely

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "symfony/framework-bundle": "^5.4 || ^6.2 || ^7.0",
+        "symfony/http-client": "^5.4 || ^6.2 || ^7.0",
         "symfony/phpunit-bridge": "^5.4 || ^6.2 || ^7.0",
         "symfony/twig-bundle": "^5.4 || ^6.2 || ^7.0",
         "symfony/web-link": "^5.4 || ^6.2 || ^7.0"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -52,6 +52,8 @@ file:
         # if you have multiple builds:
         # builds:
             # frontend: '%kernel.project_dir%/public/frontend/build'
+            # or if you use a CDN:
+            # frontend: 'https://cdn.example.com/frontend/build'
 
             # pass the build name" as the 3rd argument to the Twig functions
             # {{ encore_entry_script_tags('entry1', null, 'frontend') }}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
+  <file src="src/Asset/EntrypointLookup.php">
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->entriesData]]></code>
+    </InvalidReturnStatement>
+  </file>
   <file src="src/DependencyInjection/Configuration.php">
     <UndefinedMethod>
-      <code>children</code>
+      <code><![CDATA[children]]></code>
     </UndefinedMethod>
   </file>
 </files>

--- a/src/Asset/EntrypointLookup.php
+++ b/src/Asset/EntrypointLookup.php
@@ -119,14 +119,15 @@ class EntrypointLookup implements EntrypointLookupInterface, IntegrityDataProvid
             }
         }
 
-        if (!file_exists($this->entrypointJsonPath)) {
+        $entrypointJsonContents = file_get_contents($this->entrypointJsonPath);
+        if ($entrypointJsonContents === false) {
             if (!$this->strictMode) {
                 return [];
             }
-            throw new \InvalidArgumentException(\sprintf('Could not find the entrypoints file from Webpack: the file "%s" does not exist.', $this->entrypointJsonPath));
+            throw new \InvalidArgumentException(\sprintf('Could not find the entrypoints file from Webpack: the file "%s" does not exist or it is not readable.', $this->entrypointJsonPath));
         }
 
-        $this->entriesData = json_decode(file_get_contents($this->entrypointJsonPath), true);
+        $this->entriesData = json_decode($entrypointJsonContents, true);
 
         if (null === $this->entriesData) {
             throw new \InvalidArgumentException(\sprintf('There was a problem JSON decoding the "%s" file', $this->entrypointJsonPath));

--- a/src/DependencyInjection/WebpackEncoreExtension.php
+++ b/src/DependencyInjection/WebpackEncoreExtension.php
@@ -95,6 +95,7 @@ final class WebpackEncoreExtension extends Extension
             $cacheEnabled ? new Reference('webpack_encore.cache') : null,
             $name,
             $strictMode,
+            new Reference('http_client', ContainerBuilder::NULL_ON_INVALID_REFERENCE),
         ];
         $definition = new Definition(EntrypointLookup::class, $arguments);
         $definition->addTag('kernel.reset', ['method' => 'reset']);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -39,6 +39,7 @@
         <service id="webpack_encore.entrypoint_lookup.cache_warmer" class="Symfony\WebpackEncoreBundle\CacheWarmer\EntrypointCacheWarmer">
             <tag name="kernel.cache_warmer" />
             <argument /> <!-- build list of entrypoint paths -->
+            <argument type="service" id="http_client" on-invalid="null" />
             <argument>%kernel.cache_dir%/webpack_encore.cache.php</argument>
         </service>
 
@@ -67,5 +68,7 @@
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="webpack_encore.entrypoint_lookup_collection" />
         </service>
+
+        <service id="webpack_encore.http_client" alias="http_client" />
     </services>
 </container>

--- a/tests/fixtures/manual_template_remote.twig
+++ b/tests/fixtures/manual_template_remote.twig
@@ -1,0 +1,7 @@
+{% for jsFile in encore_entry_js_files('backend', 'remote_build') %}
+    <script src="{{ asset(jsFile) }}"></script>
+{% endfor %}
+
+{% for cssFile in encore_entry_css_files('backend', 'remote_build') %}
+    <link rel="stylesheet" href="{{ asset(cssFile) }}" />
+{% endfor %}

--- a/tests/fixtures/template_remote.twig
+++ b/tests/fixtures/template_remote.twig
@@ -1,0 +1,2 @@
+{{ encore_entry_script_tags('app', null, 'remote_build') }}
+{{ encore_entry_link_tags('app', null, 'remote_build') }}


### PR DESCRIPTION
Fixes https://github.com/symfony/webpack-encore-bundle/issues/76

See #97, this PR uses the Symfony HttpClient to remotely fetch the entrypoints file, but also to allow mocking in a proper way.
It also add/adapt many tests, and improve the documentation.