### PR TITLE
Fix missing integrity hash on preload tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.2.0
+
+- #236 Allow entrypoints.json to be hosted remotely (@rlvdx & @Kocal)
+- #232 fix: correctly wire the build-time file into kernel.build_dir (@dkarlovi)
+- #237 Fix missing integrity hash on preload (@arnaud-ritti & @Kocal)
+
 ## v2.1.0
 
 - #233 Add support for PHP 8.3 and PHP 8.4 (@Kocal)

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -28,7 +28,9 @@ class TagRenderer implements ResetInterface
     private $defaultLinkAttributes;
     private $eventDispatcher;
 
+    // TODO WebpackEncoreBundle 3.0: remove this property
     private $renderedFiles = [];
+    // TODO WebpackEncoreBundle 3.0: rename this property to $renderedFiles
     private $renderedFilesWithAttributes = [];
 
     public function __construct(
@@ -87,7 +89,7 @@ class TagRenderer implements ResetInterface
         return implode('', $scriptTags);
     }
 
-    public function renderWebpackLinkTags(string $entryName, ?string $packageName = null, ?string $entrypointName = null, array $extraAttributes = [], bool $includeAttributes = false): string
+    public function renderWebpackLinkTags(string $entryName, ?string $packageName = null, ?string $entrypointName = null, array $extraAttributes = []): string
     {
         $entrypointName = $entrypointName ?: '_default';
         $scriptTags = [];
@@ -126,24 +128,30 @@ class TagRenderer implements ResetInterface
         return implode('', $scriptTags);
     }
 
-    public function getRenderedScripts(): array
+    /**
+     * @param bool $includeAttributes Whether to include the attributes or not.
+     *                                In WebpackEncoreBundle 3.0, this parameter will be removed,
+     *                                and the attributes will always be included.
+     *                                TODO WebpackEncoreBundle 3.0
+     *
+     * @return ($includeAttributes is true ? list<array<string, mixed>> : list<string>)
+     */
+    public function getRenderedScripts(bool $includeAttributes = false): array
     {
-        return $this->renderedFiles['scripts'];
+        return $includeAttributes ? $this->renderedFilesWithAttributes['scripts'] : $this->renderedFiles['scripts'];
     }
 
-    public function getRenderedStyles(): array
+    /**
+     * @param bool $includeAttributes Whether to include the attributes or not.
+     *                                In WebpackEncoreBundle 3.0, this parameter will be removed,
+     *                                and the attributes will always be included.
+     *                                TODO WebpackEncoreBundle 3.0
+     *
+     * @return ($includeAttributes is true ? list<array<string, mixed>> : list<string>)
+     */
+    public function getRenderedStyles(bool $includeAttributes = false): array
     {
-        return $this->renderedFiles['styles'];
-    }
-
-    public function getRenderedScriptsWithAttributes(): array
-    {
-        return $this->renderedFilesWithAttributes['scripts'];
-    }
-
-    public function getRenderedStylesWithAttributes(): array
-    {
-        return $this->renderedFilesWithAttributes['styles'];
+        return $includeAttributes ? $this->renderedFilesWithAttributes['styles'] : $this->renderedFiles['styles'];
     }
 
     public function getDefaultAttributes(): array

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -80,7 +80,7 @@ class TagRenderer implements ResetInterface
                 $this->convertArrayToAttributes($attributes)
             );
 
-            $this->renderedFiles['scripts'][] = $attributes["src"];
+            $this->renderedFiles['scripts'][] = $attributes['src'];
             $this->renderedFilesWithAttributes['scripts'][] = $attributes;
         }
 
@@ -119,7 +119,7 @@ class TagRenderer implements ResetInterface
                 $this->convertArrayToAttributes($attributes)
             );
 
-            $this->renderedFiles['styles'][] = $attributes["href"];
+            $this->renderedFiles['styles'][] = $attributes['href'];
             $this->renderedFilesWithAttributes['styles'][] = $attributes;
         }
 

--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -29,6 +29,7 @@ class TagRenderer implements ResetInterface
     private $eventDispatcher;
 
     private $renderedFiles = [];
+    private $renderedFilesWithAttributes = [];
 
     public function __construct(
         EntrypointLookupCollectionInterface $entrypointLookupCollection,
@@ -48,7 +49,7 @@ class TagRenderer implements ResetInterface
         $this->reset();
     }
 
-    public function renderWebpackScriptTags(string $entryName, ?string $packageName = null, ?string $entrypointName = null, array $extraAttributes = []): string
+    public function renderWebpackScriptTags(string $entryName, ?string $packageName = null, ?string $entrypointName = null, array $extraAttributes = [], bool $includeAttributes = false): string
     {
         $entrypointName = $entrypointName ?: '_default';
         $scriptTags = [];
@@ -79,13 +80,14 @@ class TagRenderer implements ResetInterface
                 $this->convertArrayToAttributes($attributes)
             );
 
-            $this->renderedFiles['scripts'][] = $attributes['src'];
+            $this->renderedFiles['scripts'][] = $attributes["src"];
+            $this->renderedFilesWithAttributes['scripts'][] = $attributes;
         }
 
         return implode('', $scriptTags);
     }
 
-    public function renderWebpackLinkTags(string $entryName, ?string $packageName = null, ?string $entrypointName = null, array $extraAttributes = []): string
+    public function renderWebpackLinkTags(string $entryName, ?string $packageName = null, ?string $entrypointName = null, array $extraAttributes = [], bool $includeAttributes = false): string
     {
         $entrypointName = $entrypointName ?: '_default';
         $scriptTags = [];
@@ -117,7 +119,8 @@ class TagRenderer implements ResetInterface
                 $this->convertArrayToAttributes($attributes)
             );
 
-            $this->renderedFiles['styles'][] = $attributes['href'];
+            $this->renderedFiles['styles'][] = $attributes["href"];
+            $this->renderedFilesWithAttributes['styles'][] = $attributes;
         }
 
         return implode('', $scriptTags);
@@ -133,6 +136,16 @@ class TagRenderer implements ResetInterface
         return $this->renderedFiles['styles'];
     }
 
+    public function getRenderedScriptsWithAttributes(): array
+    {
+        return $this->renderedFilesWithAttributes['scripts'];
+    }
+
+    public function getRenderedStylesWithAttributes(): array
+    {
+        return $this->renderedFilesWithAttributes['styles'];
+    }
+
     public function getDefaultAttributes(): array
     {
         return $this->defaultAttributes;
@@ -140,7 +153,7 @@ class TagRenderer implements ResetInterface
 
     public function reset(): void
     {
-        $this->renderedFiles = [
+        $this->renderedFiles = $this->renderedFilesWithAttributes = [
             'scripts' => [],
             'styles' => [],
         ];

--- a/src/EventListener/PreLoadAssetsEventListener.php
+++ b/src/EventListener/PreLoadAssetsEventListener.php
@@ -52,7 +52,7 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         foreach ($this->tagRenderer->getRenderedScriptsWithAttributes() as $attributes) {
             $attributes = array_merge($defaultAttributes, $attributes);
 
-            $link = ($this->createLink('preload', $attributes['src']))->withAttribute('as', 'script');
+            $link = $this->createLink('preload', $attributes['src'])->withAttribute('as', 'script');
 
             if (!empty($attributes['crossorigin']) && false !== $attributes['crossorigin']) {
                 $link = $link->withAttribute('crossorigin', $attributes['crossorigin']);
@@ -67,7 +67,7 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         foreach ($this->tagRenderer->getRenderedStylesWithAttributes() as $attributes) {
             $attributes = array_merge($defaultAttributes, $attributes);
 
-            $link = ($this->createLink('preload', $attributes['href']))->withAttribute('as', 'style');
+            $link = $this->createLink('preload', $attributes['href'])->withAttribute('as', 'style');
 
             if (!empty($attributes['crossorigin']) && false !== $attributes['crossorigin']) {
                 $link = $link->withAttribute('crossorigin', $attributes['crossorigin']);

--- a/src/EventListener/PreLoadAssetsEventListener.php
+++ b/src/EventListener/PreLoadAssetsEventListener.php
@@ -47,33 +47,31 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         /** @var GenericLinkProvider $linkProvider */
         $linkProvider = $request->attributes->get('_links');
         $defaultAttributes = $this->tagRenderer->getDefaultAttributes();
-        $crossOrigin = $defaultAttributes['crossorigin'] ?? false;
 
-        foreach ($this->tagRenderer->getRenderedScriptsWithAttributes() as $attributes) {
-            $attributes = array_merge($defaultAttributes, $attributes);
+        foreach ($this->tagRenderer->getRenderedScripts(true) as $attributes) {
+            $src = $attributes['src'];
+            unset($attributes['src']);
+            $attributes = [...$defaultAttributes, ...$attributes];
 
-            $link = $this->createLink('preload', $attributes['src'])->withAttribute('as', 'script');
+            $link = $this->createLink('preload', $src)
+                ->withAttribute('as', 'script');
 
-            if (!empty($attributes['crossorigin']) && false !== $attributes['crossorigin']) {
-                $link = $link->withAttribute('crossorigin', $attributes['crossorigin']);
-            }
-            if (!empty($attributes['integrity'])) {
-                $link = $link->withAttribute('integrity', $attributes['integrity']);
+            foreach ($attributes as $k => $v) {
+                $link = $link->withAttribute($k, $v);
             }
 
             $linkProvider = $linkProvider->withLink($link);
         }
 
-        foreach ($this->tagRenderer->getRenderedStylesWithAttributes() as $attributes) {
-            $attributes = array_merge($defaultAttributes, $attributes);
+        foreach ($this->tagRenderer->getRenderedStyles(true) as $attributes) {
+            $href = $attributes['href'];
+            unset($attributes['href']);
+            $attributes = [...$defaultAttributes, ...$attributes];
 
-            $link = $this->createLink('preload', $attributes['href'])->withAttribute('as', 'style');
+            $link = $this->createLink('preload', $href)->withAttribute('as', 'style');
 
-            if (!empty($attributes['crossorigin']) && false !== $attributes['crossorigin']) {
-                $link = $link->withAttribute('crossorigin', $attributes['crossorigin']);
-            }
-            if (!empty($attributes['integrity'])) {
-                $link = $link->withAttribute('integrity', $attributes['integrity']);
+            foreach ($attributes as $k => $v) {
+                $link = $link->withAttribute($k, $v);
             }
 
             $linkProvider = $linkProvider->withLink($link);

--- a/src/EventListener/PreLoadAssetsEventListener.php
+++ b/src/EventListener/PreLoadAssetsEventListener.php
@@ -49,21 +49,31 @@ class PreLoadAssetsEventListener implements EventSubscriberInterface
         $defaultAttributes = $this->tagRenderer->getDefaultAttributes();
         $crossOrigin = $defaultAttributes['crossorigin'] ?? false;
 
-        foreach ($this->tagRenderer->getRenderedScripts() as $href) {
-            $link = $this->createLink('preload', $href)->withAttribute('as', 'script');
+        foreach ($this->tagRenderer->getRenderedScriptsWithAttributes() as $attributes) {
+            $attributes = array_merge($defaultAttributes, $attributes);
 
-            if (false !== $crossOrigin) {
-                $link = $link->withAttribute('crossorigin', $crossOrigin);
+            $link = ($this->createLink('preload', $attributes['src']))->withAttribute('as', 'script');
+
+            if (!empty($attributes['crossorigin']) && false !== $attributes['crossorigin']) {
+                $link = $link->withAttribute('crossorigin', $attributes['crossorigin']);
+            }
+            if (!empty($attributes['integrity'])) {
+                $link = $link->withAttribute('integrity', $attributes['integrity']);
             }
 
             $linkProvider = $linkProvider->withLink($link);
         }
 
-        foreach ($this->tagRenderer->getRenderedStyles() as $href) {
-            $link = $this->createLink('preload', $href)->withAttribute('as', 'style');
+        foreach ($this->tagRenderer->getRenderedStylesWithAttributes() as $attributes) {
+            $attributes = array_merge($defaultAttributes, $attributes);
 
-            if (false !== $crossOrigin) {
-                $link = $link->withAttribute('crossorigin', $crossOrigin);
+            $link = ($this->createLink('preload', $attributes['href']))->withAttribute('as', 'style');
+
+            if (!empty($attributes['crossorigin']) && false !== $attributes['crossorigin']) {
+                $link = $link->withAttribute('crossorigin', $attributes['crossorigin']);
+            }
+            if (!empty($attributes['integrity'])) {
+                $link = $link->withAttribute('integrity', $attributes['integrity']);
             }
 
             $linkProvider = $linkProvider->withLink($link);

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -308,18 +308,18 @@ class TagRendererTest extends TestCase
             [
                 'src' => 'http://localhost:8080/build/file2.js',
             ],
-        ], $renderer->getRenderedScriptsWithAttributes());
+        ], $renderer->getRenderedScripts(true));
         $this->assertSame([
             [
                 'rel' => 'stylesheet',
                 'href' => 'http://localhost:8080/build/file1.css',
             ],
-        ], $renderer->getRenderedStylesWithAttributes());
+        ], $renderer->getRenderedStyles(true));
 
         $renderer->reset();
         $this->assertEmpty($renderer->getRenderedScripts());
         $this->assertEmpty($renderer->getRenderedStyles());
-        $this->assertEmpty($renderer->getRenderedScriptsWithAttributes());
-        $this->assertEmpty($renderer->getRenderedStylesWithAttributes());
+        $this->assertEmpty($renderer->getRenderedScripts(true));
+        $this->assertEmpty($renderer->getRenderedStyles(true));
     }
 }

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -301,8 +301,26 @@ class TagRendererTest extends TestCase
         $this->assertSame(['http://localhost:8080/build/file1.js', 'http://localhost:8080/build/file2.js'], $renderer->getRenderedScripts());
         $this->assertSame(['http://localhost:8080/build/file1.css'], $renderer->getRenderedStyles());
 
+        $this->assertSame([
+            [
+                'src' => 'http://localhost:8080/build/file1.js',
+            ],
+            [
+                'src' => 'http://localhost:8080/build/file2.js',
+            ],
+        ], $renderer->getRenderedScriptsWithAttributes());
+        $this->assertSame([
+            [
+                'rel' => 'stylesheet',
+                'href' => 'http://localhost:8080/build/file1.css',
+            ],
+        ], $renderer->getRenderedStylesWithAttributes());
+
+
         $renderer->reset();
         $this->assertEmpty($renderer->getRenderedScripts());
         $this->assertEmpty($renderer->getRenderedStyles());
+        $this->assertEmpty($renderer->getRenderedScriptsWithAttributes());
+        $this->assertEmpty($renderer->getRenderedStylesWithAttributes());
     }
 }

--- a/tests/Asset/TagRendererTest.php
+++ b/tests/Asset/TagRendererTest.php
@@ -316,7 +316,6 @@ class TagRendererTest extends TestCase
             ],
         ], $renderer->getRenderedStylesWithAttributes());
 
-
         $renderer->reset();
         $this->assertEmpty($renderer->getRenderedScripts());
         $this->assertEmpty($renderer->getRenderedStyles());

--- a/tests/EventListener/PreLoadAssetsEventListenerTest.php
+++ b/tests/EventListener/PreLoadAssetsEventListenerTest.php
@@ -30,8 +30,17 @@ class PreLoadAssetsEventListenerTest extends TestCase
     {
         $tagRenderer = $this->createMock(TagRenderer::class);
         $tagRenderer->expects($this->once())->method('getDefaultAttributes')->willReturn(['crossorigin' => 'anonymous']);
-        $tagRenderer->expects($this->once())->method('getRenderedScripts')->willReturn(['/file1.js']);
-        $tagRenderer->expects($this->once())->method('getRenderedStyles')->willReturn(['/css/file1.css']);
+        $tagRenderer->expects($this->once())->method('getRenderedScripts')->willReturn([
+            [
+                'src' => '/file1.js',
+            ],
+        ]);
+        $tagRenderer->expects($this->once())->method('getRenderedStyles')->willReturn([
+            [
+                'rel' => 'stylesheet',
+                'href' => '/css/file1.css',
+            ],
+        ]);
 
         $request = new Request();
         $response = new Response();
@@ -60,7 +69,11 @@ class PreLoadAssetsEventListenerTest extends TestCase
     {
         $tagRenderer = $this->createMock(TagRenderer::class);
         $tagRenderer->expects($this->once())->method('getDefaultAttributes')->willReturn(['crossorigin' => 'anonymous']);
-        $tagRenderer->expects($this->once())->method('getRenderedScripts')->willReturn(['/file1.js']);
+        $tagRenderer->expects($this->once())->method('getRenderedScripts')->willReturn([
+            [
+                'src' => '/file1.js',
+            ],
+        ]);
         $tagRenderer->expects($this->once())->method('getRenderedStyles')->willReturn([]);
 
         $request = new Request();

--- a/tests/EventListener/PreLoadAssetsEventListenerTest.php
+++ b/tests/EventListener/PreLoadAssetsEventListenerTest.php
@@ -30,12 +30,12 @@ class PreLoadAssetsEventListenerTest extends TestCase
     {
         $tagRenderer = $this->createMock(TagRenderer::class);
         $tagRenderer->expects($this->once())->method('getDefaultAttributes')->willReturn(['crossorigin' => 'anonymous']);
-        $tagRenderer->expects($this->once())->method('getRenderedScripts')->willReturn([
+        $tagRenderer->expects($this->once())->method('getRenderedScripts')->with(true)->willReturn([
             [
                 'src' => '/file1.js',
             ],
         ]);
-        $tagRenderer->expects($this->once())->method('getRenderedStyles')->willReturn([
+        $tagRenderer->expects($this->once())->method('getRenderedStyles')->with(true)->willReturn([
             [
                 'rel' => 'stylesheet',
                 'href' => '/css/file1.css',
@@ -62,7 +62,7 @@ class PreLoadAssetsEventListenerTest extends TestCase
 
         $this->assertSame('/css/file1.css', $links[1]->getHref());
         $this->assertSame(['preload'], $links[1]->getRels());
-        $this->assertSame(['as' => 'style', 'crossorigin' => 'anonymous'], $links[1]->getAttributes());
+        $this->assertSame(['as' => 'style', 'crossorigin' => 'anonymous', 'rel' => 'stylesheet'], $links[1]->getAttributes());
     }
 
     public function testItReusesExistingLinkProvider()


### PR DESCRIPTION
I wasn't able to edit #161, so I've opened a new PR and made changes here.

Fix https://github.com/symfony/webpack-encore-bundle/issues/101, fix https://github.com/symfony/webpack-encore-bundle/issues/225

On an existing app, integrity hashes and other attributes are nicely injected into `Link` header: 
<img width="1101" alt="image" src="https://github.com/user-attachments/assets/3733d80f-1927-49d9-8f0e-c8e340f7ed69">
