### PR TITLE
Fix Symfony 8.1 DependencyInjection deprecation warning

### DIFF
--- a/src/DependencyInjection/WebpackEncoreExtension.php
+++ b/src/DependencyInjection/WebpackEncoreExtension.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\WebLink\EventListener\AddLinkHeaderListener;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookup;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;


### PR DESCRIPTION
| Q             | A         |
| ------------- | --------- |
| Bug fix?      | no        |
| New feature?  | no        |
| Deprecations? | no        |
| Issues        | Fix #257  |
| License       | MIT       |

Fix Symfony 8.1 DependencyInjection deprecation warning

Replaces the deprecated `Symfony\Component\HttpKernel\DependencyInjection\Extension` with `Symfony\Component\DependencyInjection\Extension\Extension` as required since Symfony 8.1.