### PR TITLE
Don't let Composer advisory blocking break CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Configure Composer minimum stability
         run: composer config minimum-stability ${{ matrix.minimum-stability || 'stable' }} --ansi
 
+      # Symfony deps may temporarily have no advisory-free release (unpatched CVE upstream);
+      # don't let Composer's advisory blocking turn the bundle's CI red in the meantime.
+      - name: Disable Composer security advisories blocking
+        run: composer config --no-plugins policy.advisories.block false
+
       - name: "Composer install"
         uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6
         with:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update CHANGELOG.md file -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Disabling Composer security advisories check in CI, see https://github.com/symfony/webpack-encore-bundle/actions/runs/28081086683/job/83135972448