### PR TITLE
Fall back to the raw path when strict mode rejects an already-resolved entrypoint

### DIFF
--- a/src/Asset/TagRenderer.php
+++ b/src/Asset/TagRenderer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\WebpackEncoreBundle\Asset;
 
+use Symfony\Component\Asset\Exception\AssetNotFoundException;
 use Symfony\Component\Asset\Packages;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -173,10 +174,19 @@ class TagRenderer implements ResetInterface
             throw new \Exception('To render the script or link tags, run "composer require symfony/asset".');
         }
 
-        return $this->packages->getUrl(
-            $assetPath,
-            $packageName
-        );
+        try {
+            return $this->packages->getUrl(
+                $assetPath,
+                $packageName
+            );
+        } catch (AssetNotFoundException) {
+            // entrypoints.json already stores the final public paths, so an
+            // asset package backed by the JSON manifest (with strict_mode
+            // enabled) cannot resolve them a second time and throws. The path
+            // is already the correct one in that case, so use it as-is, which
+            // is also what happens when strict_mode is disabled.
+            return $assetPath;
+        }
     }
 
     private function getEntrypointLookup(string $buildName): EntrypointLookupInterface

--- a/tests/Asset/TagRendererStrictModeTest.php
+++ b/tests/Asset/TagRendererStrictModeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony WebpackEncoreBundle package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\WebpackEncoreBundle\Tests\Asset;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Exception\AssetNotFoundException;
+use Symfony\Component\Asset\Packages;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupCollection;
+use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
+use Symfony\WebpackEncoreBundle\Asset\TagRenderer;
+
+/**
+ * When the default asset package is backed by the JSON manifest with
+ * strict_mode enabled, it cannot resolve the already-final entrypoint paths a
+ * second time and throws. The renderer must fall back to the raw path.
+ *
+ * @see https://github.com/symfony/webpack-encore-bundle/issues/230
+ */
+class TagRendererStrictModeTest extends TestCase
+{
+    public function testRenderScriptTagsFallsBackWhenAssetPackageCannotResolveTheEntrypointPath()
+    {
+        $entrypointLookup = $this->createMock(EntrypointLookupInterface::class);
+        $entrypointLookup->expects($this->once())
+            ->method('getJavaScriptFiles')
+            ->willReturn(['/web-subfolder/app.53d71f57.js']);
+        $entrypointCollection = $this->createMock(EntrypointLookupCollection::class);
+        $entrypointCollection->expects($this->once())
+            ->method('getEntrypointLookup')
+            ->willReturn($entrypointLookup);
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->once())
+            ->method('getUrl')
+            ->willThrowException(new AssetNotFoundException('Asset "/web-subfolder/app.53d71f57.js" not found in manifest.'));
+        $renderer = new TagRenderer($entrypointCollection, $packages);
+
+        $output = $renderer->renderWebpackScriptTags('my_entry');
+        $this->assertStringContainsString(
+            '<script src="/web-subfolder/app.53d71f57.js"></script>',
+            $output
+        );
+    }
+
+    public function testRenderLinkTagsFallsBackWhenAssetPackageCannotResolveTheEntrypointPath()
+    {
+        $entrypointLookup = $this->createMock(EntrypointLookupInterface::class);
+        $entrypointLookup->expects($this->once())
+            ->method('getCssFiles')
+            ->willReturn(['/web-subfolder/app.b75294ae.css']);
+        $entrypointCollection = $this->createMock(EntrypointLookupCollection::class);
+        $entrypointCollection->expects($this->once())
+            ->method('getEntrypointLookup')
+            ->willReturn($entrypointLookup);
+
+        $packages = $this->createMock(Packages::class);
+        $packages->expects($this->once())
+            ->method('getUrl')
+            ->willThrowException(new AssetNotFoundException('Asset "/web-subfolder/app.b75294ae.css" not found in manifest.'));
+        $renderer = new TagRenderer($entrypointCollection, $packages);
+
+        $output = $renderer->renderWebpackLinkTags('my_entry');
+        $this->assertStringContainsString(
+            '<link rel="stylesheet" href="/web-subfolder/app.b75294ae.css">',
+            $output
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Issues        | Fix #230
| License       | MIT

`entrypoints.json` already stores the final public paths of the built assets, but `TagRenderer` passes each one back through `packages->getUrl()`. When the default asset package is backed by the JSON manifest (`framework.assets.json_manifest_path`) with `framework.assets.strict_mode: true`, the strategy treats the already-resolved path as a manifest key, fails to find it and throws `AssetNotFoundException`, so `encore_entry_link_tags()` / `encore_entry_script_tags()` blow up. With `strict_mode: false` the same call silently returns the path unchanged, which is why the bug only shows up in strict mode (reported by @bmorg, kept open by @Kocal).

I reproduced it against the real asset component: `getUrl('/web-subfolder/app.b75294ae.css')` throws in strict mode, while `getUrl('my-prefix/app.css')` (the manifest key) resolves fine.

This catches `AssetNotFoundException` in `getAssetPath()` and falls back to the raw path, which is already the correct, final one, matching what `strict_mode: false` does today. Real `asset()` calls elsewhere keep their strict-mode behavior untouched. I deliberately kept the `getUrl()` call rather than removing it (as the issue suggested), since it is what applies a base path / CDN to the entrypoint values.

@Kocal, since this touches the entrypoints / manifest / base-path interaction, I went for the smallest safe fix but I'm happy to adjust the direction if you had something else in mind.

Thanks a lot for the bundle! 🙏
